### PR TITLE
fix/snowflake-tagging-spacing

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -31,7 +31,7 @@ on-run-start:
   - "{{ create_sps() }}"
   - "{{ create_udfs() }}"
 
- on-run-end:
+on-run-end:
   - '{{ apply_meta_as_tags(results) }}' 
 
 # Configuring models


### PR DESCRIPTION
1. Fixed spacing issue in dbt_project.yml that caused docs_update to fail