### PR TITLE
AN-3048/arbitrum-ez-dex-swaps

### DIFF
--- a/models/doc_descriptions/dex - (imported from layer 1)/arb_ez_dex_swaps_table_doc.md
+++ b/models/doc_descriptions/dex - (imported from layer 1)/arb_ez_dex_swaps_table_doc.md
@@ -1,0 +1,6 @@
+{% docs arb_ez_dex_swaps_table_doc %}
+
+This table currently contains swap events from the ```fact_event_logs``` table for TRADER JOE, WOOFI, GMX, KYBERSWAP, ZYBERSWAP, DODO, FRAX, CAMELOT, UNISWAP, SUSHI, CURVE and BALANCER along with other helpful columns including an amount USD where possible. Other dexes coming soon! 
+Note: A rule has been put in place to null out the amount_USD if that number is too divergent between amount_in_USD and amount_out_usd. This can happen for swaps of less liquid tokens during very high fluctuation of price.
+
+{% enddocs %}

--- a/models/doc_descriptions/general/__overview__.md
+++ b/models/doc_descriptions/general/__overview__.md
@@ -35,6 +35,7 @@ There is more information on how to use dbt docs in the last section of this doc
 - [ez_eth_transfers](https://flipsidecrypto.github.io/arbitrum-models/#!/model/model.arbitrum_models.core__ez_eth_transfers)
 - [ez_token_transfers](https://flipsidecrypto.github.io/arbitrum-models/#!/model/model.arbitrum_models.core__ez_token_transfers)
 - [ez_decoded_event_logs](https://flipsidecrypto.github.io/arbitrum-models/#!/model/model.arbitrum_models.core__ez_decoded_event_logs)
+- [ez_dex_swaps](https://flipsidecrypto.github.io/arbitrum-models/#!/model/model.arbitrum_models.core__ez_dex_swaps)
 
 ## **Helpful User-Defined Functions (UDFs)**
 

--- a/models/gold/core__ez_dex_swaps.sql
+++ b/models/gold/core__ez_dex_swaps.sql
@@ -1,0 +1,38 @@
+{{ config(
+    materialized = 'view',
+    persist_docs ={ "relation": true,
+    "columns": true },
+    meta={
+        'database_tags':{
+            'table': {
+                'PROTOCOL': 'TRADER JOE, WOOFI, GMX, KYBERSWAP, ZYBERSWAP, DODO, FRAX, CAMELOT, UNISWAP, SUSHI, CURVE, BALANCER',
+                'PURPOSE': 'DEX, SWAPS'
+            }
+        }
+    }
+) }}
+
+SELECT
+  block_number,
+  block_timestamp,
+  tx_hash,
+  origin_function_signature,
+  origin_from_address,
+  origin_to_address,
+  contract_address,
+  pool_name,
+  event_name,
+  amount_in,
+  amount_in_usd,
+  amount_out,
+  amount_out_usd,
+  sender,
+  tx_to,
+  event_index,
+  platform,
+  token_in,
+  token_out,
+  symbol_in,
+  symbol_out,
+  _log_id
+FROM {{ ref('silver_dex__complete_dex_swaps') }}

--- a/models/gold/core__ez_dex_swaps.yml
+++ b/models/gold/core__ez_dex_swaps.yml
@@ -1,0 +1,49 @@
+version: 2
+models:
+  - name: core__ez_dex_swaps
+    description: '{{ doc("arb_ez_dex_swaps_table_doc") }}'
+
+    columns:
+      - name: BLOCK_NUMBER
+        description: '{{ doc("arb_block_number") }}'
+      - name: BLOCK_TIMESTAMP
+        description: '{{ doc("arb_block_timestamp") }}'
+      - name: TX_HASH
+        description: '{{ doc("arb_logs_tx_hash") }}'
+      - name: CONTRACT_ADDRESS
+        description: '{{ doc("arb_logs_contract_address") }}'
+      - name: EVENT_NAME
+        description: '{{ doc("arb_event_name") }}'
+      - name: AMOUNT_IN
+        description: '{{ doc("eth_dex_swaps_amount_in") }}'
+      - name: AMOUNT_OUT
+        description: '{{ doc("eth_dex_swaps_amount_out") }}'
+      - name: AMOUNT_IN_USD
+        description: '{{ doc("eth_dex_swaps_amount_in_usd") }}'
+      - name: AMOUNT_OUT_USD
+        description: '{{ doc("eth_dex_swaps_amount_out_usd") }}'
+      - name: TOKEN_IN
+        description: '{{ doc("eth_dex_swaps_token_in") }}'
+      - name: TOKEN_OUT
+        description: '{{ doc("eth_dex_swaps_token_out") }}'
+      - name: SYMBOL_IN
+        description: '{{ doc("eth_dex_swaps_symbol_in") }}'
+      - name: SYMBOL_OUT
+        description: '{{ doc("eth_dex_swaps_symbol_out") }}'
+      - name: SENDER
+        description: '{{ doc("eth_dex_swaps_sender") }}'
+      - name: TX_TO
+        description: '{{ doc("eth_dex_swaps_tx_to") }}'
+      - name: PLATFORM
+        description: '{{ doc("eth_dex_platform") }}'
+      - name: EVENT_INDEX
+        description: '{{ doc("arb_event_index") }}'
+      - name: _LOG_ID
+        description: '{{ doc("arb_log_id_events") }}'
+      - name: ORIGIN_FUNCTION_SIGNATURE
+        description: '{{ doc("arb_tx_origin_sig") }}'
+      - name: ORIGIN_FROM_ADDRESS
+        description: '{{ doc("arb_origin_from") }}'
+      - name: ORIGIN_TO_ADDRESS
+        description: '{{ doc("arb_origin_to") }}'
+

--- a/models/silver/dex/balancer/silver_dex__balancer_pools.sql
+++ b/models/silver/dex/balancer/silver_dex__balancer_pools.sql
@@ -14,7 +14,7 @@ WITH pool_creation AS (
         _inserted_timestamp,
         ROW_NUMBER() OVER (ORDER BY contract_address) AS row_num
     FROM
-        {{ ref('silver__logs2') }}
+        {{ ref('silver__logs') }}
     WHERE
         topics[0]::STRING = '0x3c13bc30b8e878c53fd2a36b679409c073afd75950be43d8858768e956fbc20e'
         AND contract_address = '0xba12222222228d8ba445958a75a0704d566bf2c8'

--- a/models/silver/dex/balancer/silver_dex__balancer_pools.sql
+++ b/models/silver/dex/balancer/silver_dex__balancer_pools.sql
@@ -1,0 +1,169 @@
+{{ config(
+    materialized = 'incremental',
+    unique_key = "pool_address",
+    full_refresh = false
+) }}
+
+WITH pool_creation AS (
+
+    SELECT
+        tx_hash,
+        topics [1] :: STRING AS pool_id,
+        SUBSTR(topics [1] :: STRING,1,42) AS contract_address,
+        block_number,
+        _inserted_timestamp,
+        ROW_NUMBER() OVER (ORDER BY contract_address) AS row_num
+    FROM
+        {{ ref('silver__logs2') }}
+    WHERE
+        topics[0]::STRING = '0x3c13bc30b8e878c53fd2a36b679409c073afd75950be43d8858768e956fbc20e'
+        AND contract_address = '0xba12222222228d8ba445958a75a0704d566bf2c8'
+{% if is_incremental() %}
+AND _inserted_timestamp >= (
+    SELECT
+        MAX(_inserted_timestamp) :: DATE
+    FROM
+        {{ this }}
+)
+AND contract_address NOT IN (
+        SELECT
+            DISTINCT pool_address
+        FROM
+            {{ this }}
+    )
+{% endif %}
+
+),
+
+function_sigs AS (
+
+SELECT
+    '0x06fdde03' AS function_sig, 
+    'name' AS function_name
+UNION ALL
+SELECT
+    '0x95d89b41' AS function_sig, 
+    'symbol' AS function_name
+UNION ALL
+SELECT
+    '0x313ce567' AS function_sig, 
+    'decimals' AS function_name
+),
+
+inputs_pools AS (
+
+SELECT
+    contract_address,
+    block_number,
+    function_sig,
+    (ROW_NUMBER() OVER (PARTITION BY contract_address
+        ORDER BY block_number)) - 1 AS function_input
+FROM pool_creation
+JOIN function_sigs ON 1=1 
+),
+
+pool_token_reads AS (
+
+{% for item in range(50) %}
+(
+SELECT
+    ethereum.streamline.udf_json_rpc_read_calls(
+        node_url,
+        headers,
+        PARSE_JSON(batch_read)
+    ) AS read_output,
+    SYSDATE() AS _inserted_timestamp
+FROM (
+    SELECT
+        CONCAT('[', LISTAGG(read_input, ','), ']') AS batch_read
+    FROM (
+        SELECT 
+            contract_address,
+            block_number,
+            function_sig,
+            function_input,
+            CONCAT(
+                '[\'',
+                contract_address,
+                '\',',
+                block_number,
+                ',\'',
+                function_sig,
+                '\',\'',
+                function_input,
+                '\']'
+                ) AS read_input,
+                row_num
+        FROM inputs_pools
+        LEFT JOIN pool_creation USING(contract_address) 
+            ) ready_reads_pools
+    WHERE row_num BETWEEN {{ item * 50 + 1 }} AND {{ (item + 1) * 50}}
+    ) batch_reads_pools
+JOIN {{ source(
+            'streamline_crosschain',
+            'node_mapping'
+        ) }} ON 1=1 
+    AND chain = 'arbitrum'
+) {% if not loop.last %}
+UNION ALL
+{% endif %}
+{% endfor %}
+),
+
+reads_adjusted AS (
+    
+SELECT
+        VALUE :id :: STRING AS read_id,
+        VALUE :result :: STRING AS read_result,
+        SPLIT(
+            read_id,
+            '-'
+        ) AS read_id_object,
+        read_id_object [0] :: STRING AS contract_address,
+        read_id_object [1] :: STRING AS block_number,
+        read_id_object [2] :: STRING AS function_sig,
+        read_id_object [3] :: STRING AS function_input,
+        _inserted_timestamp
+FROM
+    pool_token_reads,
+    LATERAL FLATTEN(
+        input => read_output [0] :data
+    ) 
+),
+
+pool_details AS (
+
+SELECT
+    contract_address AS pool_address,
+    function_sig,
+    function_name,
+    read_result,
+    regexp_substr_all(SUBSTR(read_result, 3, len(read_result)), '.{64}') AS segmented_output,
+    _inserted_timestamp
+FROM reads_adjusted
+LEFT JOIN function_sigs USING(function_sig)
+    ),
+
+FINAL AS (
+SELECT
+    pool_address,
+    MIN(CASE WHEN function_name = 'symbol' THEN TRY_HEX_DECODE_STRING(segmented_output [2] :: STRING) END) AS pool_symbol,
+    MIN(CASE WHEN function_name = 'name' THEN TRY_HEX_DECODE_STRING(segmented_output [2] :: STRING) END) AS pool_name,
+    MIN(CASE 
+            WHEN read_result::STRING = '0x' THEN NULL
+            ELSE utils.udf_hex_to_int(LEFT(read_result::STRING,66))
+        END)::INTEGER  AS pool_decimals,
+    MAX(_inserted_timestamp) AS _inserted_timestamp
+FROM pool_details
+GROUP BY 1
+)
+
+SELECT
+    pool_address,
+    pool_symbol,
+    pool_name,
+    pool_decimals,
+    _inserted_timestamp
+FROM FINAL 
+WHERE pool_name IS NOT NULL 
+    AND pool_symbol IS NOT NULL

--- a/models/silver/dex/balancer/silver_dex__balancer_pools.sql
+++ b/models/silver/dex/balancer/silver_dex__balancer_pools.sql
@@ -1,23 +1,30 @@
 {{ config(
     materialized = 'incremental',
     unique_key = "pool_address",
-    full_refresh = false
 ) }}
-
+--    full_refresh = false
 WITH pool_creation AS (
 
     SELECT
         tx_hash,
         topics [1] :: STRING AS pool_id,
-        SUBSTR(topics [1] :: STRING,1,42) AS contract_address,
+        SUBSTR(
+            topics [1] :: STRING,
+            1,
+            42
+        ) AS contract_address,
         block_number,
         _inserted_timestamp,
-        ROW_NUMBER() OVER (ORDER BY contract_address) AS row_num
+        ROW_NUMBER() over (
+            ORDER BY
+                contract_address
+        ) AS row_num
     FROM
         {{ ref('silver__logs') }}
     WHERE
-        topics[0]::STRING = '0x3c13bc30b8e878c53fd2a36b679409c073afd75950be43d8858768e956fbc20e'
+        topics [0] :: STRING = '0x3c13bc30b8e878c53fd2a36b679409c073afd75950be43d8858768e956fbc20e'
         AND contract_address = '0xba12222222228d8ba445958a75a0704d566bf2c8'
+
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
@@ -26,93 +33,65 @@ AND _inserted_timestamp >= (
         {{ this }}
 )
 AND contract_address NOT IN (
-        SELECT
-            DISTINCT pool_address
-        FROM
-            {{ this }}
-    )
-{% endif %}
-
-),
-
-function_sigs AS (
-
-SELECT
-    '0x06fdde03' AS function_sig, 
-    'name' AS function_name
-UNION ALL
-SELECT
-    '0x95d89b41' AS function_sig, 
-    'symbol' AS function_name
-UNION ALL
-SELECT
-    '0x313ce567' AS function_sig, 
-    'decimals' AS function_name
-),
-
-inputs_pools AS (
-
-SELECT
-    contract_address,
-    block_number,
-    function_sig,
-    (ROW_NUMBER() OVER (PARTITION BY contract_address
-        ORDER BY block_number)) - 1 AS function_input
-FROM pool_creation
-JOIN function_sigs ON 1=1 
-),
-
-pool_token_reads AS (
-
-{% for item in range(50) %}
-(
-SELECT
-    ethereum.streamline.udf_json_rpc_read_calls(
-        node_url,
-        headers,
-        PARSE_JSON(batch_read)
-    ) AS read_output,
-    SYSDATE() AS _inserted_timestamp
-FROM (
     SELECT
-        CONCAT('[', LISTAGG(read_input, ','), ']') AS batch_read
-    FROM (
-        SELECT 
-            contract_address,
-            block_number,
-            function_sig,
-            function_input,
-            CONCAT(
-                '[\'',
-                contract_address,
-                '\',',
-                block_number,
-                ',\'',
-                function_sig,
-                '\',\'',
-                function_input,
-                '\']'
-                ) AS read_input,
-                row_num
-        FROM inputs_pools
-        LEFT JOIN pool_creation USING(contract_address) 
-            ) ready_reads_pools
-    WHERE row_num BETWEEN {{ item * 50 + 1 }} AND {{ (item + 1) * 50}}
-    ) batch_reads_pools
-JOIN {{ source(
-            'streamline_crosschain',
-            'node_mapping'
-        ) }} ON 1=1 
-    AND chain = 'arbitrum'
-) {% if not loop.last %}
-UNION ALL
+        DISTINCT pool_address
+    FROM
+        {{ this }}
+)
 {% endif %}
-{% endfor %}
 ),
-
-reads_adjusted AS (
-    
+function_sigs AS (
+    SELECT
+        '0x06fdde03' AS function_sig,
+        'name' AS function_name
+    UNION ALL
+    SELECT
+        '0x95d89b41' AS function_sig,
+        'symbol' AS function_name
+    UNION ALL
+    SELECT
+        '0x313ce567' AS function_sig,
+        'decimals' AS function_name
+),
+inputs_pools AS (
+    SELECT
+        contract_address,
+        block_number,
+        function_sig,
+        (ROW_NUMBER() over (PARTITION BY contract_address
+    ORDER BY
+        block_number)) - 1 AS function_input
+    FROM
+        pool_creation
+        JOIN function_sigs
+        ON 1 = 1
+),
+pool_token_reads AS ({% for item in range(50) %}
+    (
 SELECT
+    ethereum.streamline.udf_json_rpc_read_calls(node_url, headers, PARSE_JSON(batch_read)) AS read_output, SYSDATE() AS _inserted_timestamp
+FROM
+    (
+SELECT
+    CONCAT('[', LISTAGG(read_input, ','), ']') AS batch_read
+FROM
+    (
+SELECT
+    contract_address, block_number, function_sig, function_input, CONCAT('[\'', contract_address, '\',', block_number, ',\'', function_sig, '\',\'', function_input, '\']') AS read_input, row_num
+FROM
+    inputs_pools
+    LEFT JOIN pool_creation USING(contract_address)) ready_reads_pools
+WHERE
+    row_num BETWEEN {{ item * 50 + 1 }}
+    AND {{(item + 1) * 50 }}) batch_reads_pools
+    JOIN {{ source('streamline_crosschain', 'node_mapping') }}
+    ON 1 = 1
+    AND chain = 'arbitrum') {% if not loop.last %}
+    UNION ALL
+    {% endif %}
+{% endfor %}),
+reads_adjusted AS (
+    SELECT
         VALUE :id :: STRING AS read_id,
         VALUE :result :: STRING AS read_result,
         SPLIT(
@@ -124,46 +103,61 @@ SELECT
         read_id_object [2] :: STRING AS function_sig,
         read_id_object [3] :: STRING AS function_input,
         _inserted_timestamp
-FROM
-    pool_token_reads,
-    LATERAL FLATTEN(
-        input => read_output [0] :data
-    ) 
+    FROM
+        pool_token_reads,
+        LATERAL FLATTEN(
+            input => read_output [0] :data
+        )
 ),
-
 pool_details AS (
-
-SELECT
-    contract_address AS pool_address,
-    function_sig,
-    function_name,
-    read_result,
-    regexp_substr_all(SUBSTR(read_result, 3, len(read_result)), '.{64}') AS segmented_output,
-    _inserted_timestamp
-FROM reads_adjusted
-LEFT JOIN function_sigs USING(function_sig)
-    ),
-
+    SELECT
+        contract_address AS pool_address,
+        function_sig,
+        function_name,
+        read_result,
+        regexp_substr_all(SUBSTR(read_result, 3, len(read_result)), '.{64}') AS segmented_output,
+        _inserted_timestamp
+    FROM
+        reads_adjusted
+        LEFT JOIN function_sigs USING(function_sig)
+),
 FINAL AS (
-SELECT
-    pool_address,
-    MIN(CASE WHEN function_name = 'symbol' THEN TRY_HEX_DECODE_STRING(segmented_output [2] :: STRING) END) AS pool_symbol,
-    MIN(CASE WHEN function_name = 'name' THEN TRY_HEX_DECODE_STRING(segmented_output [2] :: STRING) END) AS pool_name,
-    MIN(CASE 
-            WHEN read_result::STRING = '0x' THEN NULL
-            ELSE utils.udf_hex_to_int(LEFT(read_result::STRING,66))
-        END)::INTEGER  AS pool_decimals,
-    MAX(_inserted_timestamp) AS _inserted_timestamp
-FROM pool_details
-GROUP BY 1
+    SELECT
+        pool_address,
+        MIN(
+            CASE
+                WHEN function_name = 'symbol' THEN TRY_HEX_DECODE_STRING(
+                    segmented_output [2] :: STRING
+                )
+            END
+        ) AS pool_symbol,
+        MIN(
+            CASE
+                WHEN function_name = 'name' THEN TRY_HEX_DECODE_STRING(
+                    segmented_output [2] :: STRING
+                )
+            END
+        ) AS pool_name,
+        MIN(
+            CASE
+                WHEN read_result :: STRING = '0x' THEN NULL
+                ELSE utils.udf_hex_to_int(LEFT(read_result :: STRING, 66))
+            END
+        ) :: INTEGER AS pool_decimals,
+        MAX(_inserted_timestamp) AS _inserted_timestamp
+    FROM
+        pool_details
+    GROUP BY
+        1
 )
-
 SELECT
     pool_address,
     pool_symbol,
     pool_name,
     pool_decimals,
     _inserted_timestamp
-FROM FINAL 
-WHERE pool_name IS NOT NULL 
+FROM
+    FINAL
+WHERE
+    pool_name IS NOT NULL
     AND pool_symbol IS NOT NULL

--- a/models/silver/dex/balancer/silver_dex__balancer_pools.yml
+++ b/models/silver/dex/balancer/silver_dex__balancer_pools.yml
@@ -1,0 +1,12 @@
+version: 2
+models:
+  - name: silver_dex__balancer_pools
+   
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - POOL_ADDRESS
+    
+      
+      
+ 

--- a/models/silver/dex/balancer/silver_dex__balancer_swaps.sql
+++ b/models/silver/dex/balancer/silver_dex__balancer_swaps.sql
@@ -48,7 +48,7 @@ swaps_base AS (
         origin_from_address AS sender,
         origin_from_address AS tx_to
     FROM
-        {{ ref('silver__logs2') }}
+        {{ ref('silver__logs') }}
     WHERE
         topics [0] :: STRING = '0x2170c741c41531aec20e7c107c24eecfdd15e69c9bb0a8dd37b1840b9e0b207b'
         AND contract_address = '0xba12222222228d8ba445958a75a0704d566bf2c8'

--- a/models/silver/dex/balancer/silver_dex__balancer_swaps.sql
+++ b/models/silver/dex/balancer/silver_dex__balancer_swaps.sql
@@ -1,0 +1,91 @@
+{{ config(
+    materialized = 'incremental',
+    unique_key = '_log_id',
+    cluster_by = ['block_timestamp::DATE']
+) }}
+
+WITH pools AS (
+
+    SELECT
+        pool_name,
+        pool_address
+    FROM
+        {{ ref('silver_dex__balancer_pools') }}
+),
+swaps_base AS (
+    SELECT
+        tx_hash,
+        block_number,
+        block_timestamp,
+        origin_function_signature,
+        origin_from_address,
+        origin_to_address,
+        contract_address,
+        'Swap' AS event_name,
+        event_index,
+        regexp_substr_all(SUBSTR(DATA, 3, len(DATA)), '.{64}') AS segmented_data,
+        TRY_TO_NUMBER(
+            utils.udf_hex_to_int(
+                segmented_data [0] :: STRING
+            )
+        ) AS amount_in_unadj,
+        TRY_TO_NUMBER(
+            utils.udf_hex_to_int(
+                segmented_data [1] :: STRING
+            )
+        ) AS amount_out_unadj,
+        topics [1] :: STRING AS pool_id,
+        CONCAT('0x', SUBSTR(topics [2] :: STRING, 27, 40)) AS token_in,
+        CONCAT('0x', SUBSTR(topics [3] :: STRING, 27, 40)) AS token_out,
+        SUBSTR(
+            topics [1] :: STRING,
+            1,
+            42
+        ) AS pool_address,
+        _log_id,
+        _inserted_timestamp,
+        'balancer' AS platform,
+        origin_from_address AS sender,
+        origin_from_address AS tx_to
+    FROM
+        {{ ref('silver__logs2') }}
+    WHERE
+        topics [0] :: STRING = '0x2170c741c41531aec20e7c107c24eecfdd15e69c9bb0a8dd37b1840b9e0b207b'
+        AND contract_address = '0xba12222222228d8ba445958a75a0704d566bf2c8'
+
+{% if is_incremental() %}
+AND _inserted_timestamp >= (
+    SELECT
+        MAX(_inserted_timestamp) :: DATE
+    FROM
+        {{ this }}
+)
+{% endif %}
+)
+SELECT
+    tx_hash,
+    block_number,
+    block_timestamp,
+    origin_function_signature,
+    origin_from_address,
+    origin_to_address,
+    event_index,
+    amount_in_unadj,
+    amount_out_unadj,
+    token_in,
+    token_out,
+    sender,
+    tx_to,
+    pool_id,
+    s.pool_address AS contract_address,
+    pool_name,
+    event_name,
+    platform,
+    _log_id,
+    _inserted_timestamp
+FROM
+    swaps_base s
+    LEFT JOIN pools p
+    ON p.pool_address = s.pool_address
+WHERE
+    pool_name IS NOT NULL

--- a/models/silver/dex/balancer/silver_dex__balancer_swaps.yml
+++ b/models/silver/dex/balancer/silver_dex__balancer_swaps.yml
@@ -1,0 +1,66 @@
+version: 2
+models:
+  - name: silver_dex__balancer_swaps
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - _log_id
+    columns:
+      - name: AMOUNT_IN_UNADJ
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - decimal
+                - float
+                - number
+      - name: AMOUNT_OUT_UNADJ
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - decimal
+                - float
+                - number
+      - name: TOKEN_IN
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: TOKEN_OUT
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: BLOCK_TIMESTAMP
+        tests:
+          - not_null
+          - dbt_expectations.expect_row_values_to_have_recent_data:
+              datepart: day
+              interval: 1
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - TIMESTAMP_LTZ
+                - TIMESTAMP_NTZ
+      - name: EVENT_INDEX
+        tests:
+          - not_null
+      - name: CONTRACT_ADDRESS
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: POOL_NAME
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - varchar
+      - name: SENDER
+        tests:
+          - not_null
+      - name: TX_TO
+        tests:
+          - not_null
+      - name: TX_HASH
+        tests:
+          - not_null

--- a/models/silver/dex/camelot/silver_dex__camelot_pools.sql
+++ b/models/silver/dex/camelot/silver_dex__camelot_pools.sql
@@ -23,10 +23,14 @@ WITH pool_creation AS (
         contract_address IN (
             '0x6eccab422d763ac031210895c81787e87b43a652',
             --v2
-            '0xd490f2f6990c0291597fd1247651b4e0dcf684dd'
+            '0xd490f2f6990c0291597fd1247651b4e0dcf684dd',
+            '0x1a3c9b1d2f0529d97f2afc5136cc23e58f1fd35b'
         ) --v3
-        AND topics [0] :: STRING IN ('0x0d3648bd0f6ba80134a33ba9275ac585d9d315f0ad8355cddefde31afa28d0e9', --PairCreated v2
-        '0x91ccaa7a278130b65168c3a0c8d3bcae84cf5e43704342bd3ec0b59e59c036db') --v3
+        AND topics [0] :: STRING IN (
+            '0x0d3648bd0f6ba80134a33ba9275ac585d9d315f0ad8355cddefde31afa28d0e9',
+            --PairCreated v2
+            '0x91ccaa7a278130b65168c3a0c8d3bcae84cf5e43704342bd3ec0b59e59c036db'
+        ) --v3
 
 {% if is_incremental() %}
 AND _inserted_timestamp >= (

--- a/models/silver/dex/camelot/silver_dex__camelot_pools.sql
+++ b/models/silver/dex/camelot/silver_dex__camelot_pools.sql
@@ -1,0 +1,56 @@
+{{ config(
+    materialized = 'incremental',
+    unique_key = "pool_address"
+) }}
+
+WITH pool_creation AS (
+
+    SELECT
+        block_number,
+        block_timestamp,
+        tx_hash,
+        event_index,
+        contract_address,
+        regexp_substr_all(SUBSTR(DATA, 3, len(DATA)), '.{64}') AS segmented_data,
+        CONCAT('0x', SUBSTR(topics [1] :: STRING, 27, 40)) AS token0,
+        CONCAT('0x', SUBSTR(topics [2] :: STRING, 27, 40)) AS token1,
+        CONCAT('0x', SUBSTR(segmented_data [0] :: STRING, 25, 40)) AS pool_address,
+        _log_id,
+        _inserted_timestamp
+    FROM
+        {{ ref ('silver__logs2') }}
+    WHERE
+        contract_address IN (
+            '0x6eccab422d763ac031210895c81787e87b43a652',
+            --v2
+            '0xd490f2f6990c0291597fd1247651b4e0dcf684dd'
+        ) --v3
+        AND topics [0] :: STRING IN ('0x0d3648bd0f6ba80134a33ba9275ac585d9d315f0ad8355cddefde31afa28d0e9', --PairCreated v2
+        '0x91ccaa7a278130b65168c3a0c8d3bcae84cf5e43704342bd3ec0b59e59c036db') --v3
+
+{% if is_incremental() %}
+AND _inserted_timestamp >= (
+    SELECT
+        MAX(_inserted_timestamp) :: DATE
+    FROM
+        {{ this }}
+)
+AND pool_address NOT IN (
+    SELECT
+        DISTINCT pool_address
+    FROM
+        {{ this }}
+)
+{% endif %}
+)
+SELECT
+    block_number,
+    block_timestamp,
+    tx_hash,
+    event_index,
+    token0,
+    token1,
+    pool_address,
+    _inserted_timestamp
+FROM
+    pool_creation

--- a/models/silver/dex/camelot/silver_dex__camelot_pools.sql
+++ b/models/silver/dex/camelot/silver_dex__camelot_pools.sql
@@ -18,7 +18,7 @@ WITH pool_creation AS (
         _log_id,
         _inserted_timestamp
     FROM
-        {{ ref ('silver__logs2') }}
+        {{ ref ('silver__logs') }}
     WHERE
         contract_address IN (
             '0x6eccab422d763ac031210895c81787e87b43a652',

--- a/models/silver/dex/camelot/silver_dex__camelot_pools.yml
+++ b/models/silver/dex/camelot/silver_dex__camelot_pools.yml
@@ -1,0 +1,23 @@
+version: 2
+models:
+  - name: silver_dex__camelot_pools
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - POOL_ADDRESS
+    columns:
+      - name: POOL_ADDRESS
+        tests:
+          - not_null
+      - name: TOKEN0
+        tests:
+          - not_null
+      - name: TOKEN1
+        tests:
+          - not_null
+      - name: _INSERTED_TIMESTAMP
+        tests: 
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - TIMESTAMP_LTZ
+                - TIMESTAMP_NTZ

--- a/models/silver/dex/camelot/silver_dex__camelot_v2_swaps.sql
+++ b/models/silver/dex/camelot/silver_dex__camelot_v2_swaps.sql
@@ -1,0 +1,116 @@
+{{ config(
+    materialized = 'incremental',
+    unique_key = '_log_id',
+    cluster_by = ['block_timestamp::DATE']
+) }}
+
+WITH pools AS (
+
+    SELECT
+        pool_address,
+        token0,
+        token1
+    FROM
+        {{ ref('silver_dex__camelot_pools') }}
+),
+swaps_base AS (
+    SELECT
+        block_number,
+        origin_function_signature,
+        origin_from_address,
+        origin_to_address,
+        block_timestamp,
+        tx_hash,
+        event_index,
+        contract_address,
+        regexp_substr_all(SUBSTR(DATA, 3, len(DATA)), '.{64}') AS segmented_data,
+        TRY_TO_NUMBER(
+            utils.udf_hex_to_int(
+                segmented_data [0] :: STRING
+            ) :: INTEGER
+        ) AS amount0In,
+        TRY_TO_NUMBER(
+            utils.udf_hex_to_int(
+                segmented_data [1] :: STRING
+            ) :: INTEGER
+        ) AS amount1In,
+        TRY_TO_NUMBER(
+            utils.udf_hex_to_int(
+                segmented_data [2] :: STRING
+            ) :: INTEGER
+        ) AS amount0Out,
+        TRY_TO_NUMBER(
+            utils.udf_hex_to_int(
+                segmented_data [3] :: STRING
+            ) :: INTEGER
+        ) AS amount1Out,
+        CONCAT('0x', SUBSTR(topics [1] :: STRING, 27, 40)) AS sender,
+        CONCAT('0x', SUBSTR(topics [2] :: STRING, 27, 40)) AS tx_to,
+        token0,
+        token1,
+        _log_id,
+        _inserted_timestamp
+    FROM
+        {{ ref('silver__logs2') }}
+        INNER JOIN pools p
+        ON p.pool_address = contract_address
+    WHERE
+        topics [0] :: STRING = '0xd78ad95fa46c994b6551d0da85fc275fe613ce37657fb8d5e3d130840159d822'
+        AND tx_status = 'SUCCESS'
+
+{% if is_incremental() %}
+AND _inserted_timestamp >= (
+    SELECT
+        MAX(_inserted_timestamp) :: DATE
+    FROM
+        {{ this }}
+)
+{% endif %}
+)
+SELECT
+    block_number,
+    block_timestamp,
+    origin_function_signature,
+    origin_from_address,
+    origin_to_address,
+    tx_hash,
+    event_index,
+    contract_address,
+    sender,
+    tx_to,
+    amount0In,
+    amount1In,
+    amount0Out,
+    amount1Out,
+    token0,
+    token1,
+    CASE
+        WHEN amount0In <> 0
+        AND amount1In <> 0
+        AND amount0Out <> 0 THEN amount1In
+        WHEN amount0In <> 0 THEN amount0In
+        WHEN amount1In <> 0 THEN amount1In
+    END AS amount_in_unadj,
+    CASE
+        WHEN amount0Out <> 0 THEN amount0Out
+        WHEN amount1Out <> 0 THEN amount1Out
+    END AS amount_out_unadj,
+    CASE
+        WHEN amount0In <> 0
+        AND amount1In <> 0
+        AND amount0Out <> 0 THEN token1
+        WHEN amount0In <> 0 THEN token0
+        WHEN amount1In <> 0 THEN token1
+    END AS token_in,
+    CASE
+        WHEN amount0Out <> 0 THEN token0
+        WHEN amount1Out <> 0 THEN token1
+    END AS token_out,
+    'Swap' AS event_name,
+    'camelot-v2' AS platform,
+    _log_id,
+    _inserted_timestamp
+FROM
+    swaps_base
+WHERE
+    token_in <> token_out

--- a/models/silver/dex/camelot/silver_dex__camelot_v2_swaps.sql
+++ b/models/silver/dex/camelot/silver_dex__camelot_v2_swaps.sql
@@ -51,7 +51,7 @@ swaps_base AS (
         _log_id,
         _inserted_timestamp
     FROM
-        {{ ref('silver__logs2') }}
+        {{ ref('silver__logs') }}
         INNER JOIN pools p
         ON p.pool_address = contract_address
     WHERE

--- a/models/silver/dex/camelot/silver_dex__camelot_v2_swaps.yml
+++ b/models/silver/dex/camelot/silver_dex__camelot_v2_swaps.yml
@@ -1,0 +1,116 @@
+version: 2
+models:
+  - name: silver_dex__camelot_v2_swaps
+
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - _LOG_ID
+    columns:
+      - name: BLOCK_NUMBER
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - FLOAT
+      - name: BLOCK_TIMESTAMP
+        tests:
+          - not_null
+          - dbt_expectations.expect_row_values_to_have_recent_data:
+              datepart: day
+              interval: 2
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - TIMESTAMP_LTZ
+                - TIMESTAMP_NTZ
+      - name: TX_HASH
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: CONTRACT_ADDRESS
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: AMOUNT_IN_UNADJ
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - FLOAT
+      - name: AMOUNT_IN
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - FLOAT
+      - name: AMOUNT_OUT_UNADJ
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - FLOAT
+      - name: AMOUNT_OUT
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - FLOAT
+      - name: TOKEN_IN
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+
+      - name: TOKEN_OUT
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: SYMBOL_IN
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - STRING
+                - VARCHAR
+      - name: SYMBOL_OUT
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - STRING
+                - VARCHAR
+      - name: TX_TO
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: PLATFORM
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - STRING
+                - VARCHAR
+      - name: EVENT_INDEX
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - FLOAT
+      - name: _LOG_ID
+        tests:
+          - not_null
+      - name: ORIGIN_FUNCTION_SIGNATURE
+        tests:
+          - not_null
+      - name: ORIGIN_FROM_ADDRESS
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: ORIGIN_TO_ADDRESS
+        tests:
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+

--- a/models/silver/dex/camelot/silver_dex__camelot_v3_swaps.sql
+++ b/models/silver/dex/camelot/silver_dex__camelot_v3_swaps.sql
@@ -1,0 +1,113 @@
+{{ config(
+    materialized = 'incremental',
+    unique_key = '_log_id',
+    cluster_by = ['block_timestamp::DATE']
+) }}
+
+WITH pools AS (
+
+    SELECT
+        pool_address,
+        token0,
+        token1
+    FROM
+        {{ ref('silver_dex__camelot_pools') }}
+),
+swaps_base AS (
+    SELECT
+        block_number,
+        origin_function_signature,
+        origin_from_address,
+        origin_to_address,
+        block_timestamp,
+        tx_hash,
+        event_index,
+        contract_address,
+        regexp_substr_all(SUBSTR(l.data, 3, len(l.data)), '.{64}') AS l_segmented_data,
+        CONCAT('0x', SUBSTR(l.topics [1] :: STRING, 27, 40)) AS sender_address,
+        CONCAT('0x', SUBSTR(l.topics [2] :: STRING, 27, 40)) AS reipient_address,
+        TRY_TO_NUMBER(
+            utils.udf_hex_to_int(
+                's2c',
+                l_segmented_data [0] :: STRING
+            )
+        ) AS amount0,
+        TRY_TO_NUMBER(
+            utils.udf_hex_to_int(
+                's2c',
+                l_segmented_data [1] :: STRING
+            )
+        ) AS amount1,
+        TRY_TO_NUMBER(
+            utils.udf_hex_to_int(
+                l_segmented_data [2] :: STRING
+            )
+        ) AS price,
+        TRY_TO_NUMBER(
+            utils.udf_hex_to_int(
+                l_segmented_data [3] :: STRING
+            )
+        ) AS liquidity,
+        TRY_TO_NUMBER(
+            utils.udf_hex_to_int(
+                's2c',
+                l_segmented_data [4] :: STRING
+            )
+        ) AS tick,
+        ABS(GREATEST(amount0, amount1)) AS amountOut,
+        ABS(LEAST(amount0, amount1)) AS amountIn,
+        token0,
+        token1,
+        CASE
+            WHEN amount0 < 0 THEN token0
+            ELSE token1
+        END AS token_in,
+        CASE
+            WHEN amount0 > 0 THEN token0
+            ELSE token1
+        END AS token_out,
+        _log_id,
+        _inserted_timestamp
+    FROM
+        {{ ref('silver__logs2') }} l
+        INNER JOIN pools p
+        ON p.pool_address = contract_address
+    WHERE
+        topics [0] :: STRING = '0xc42079f94a6350d7e6235f29174924f928cc2ac818eb64fed8004e115fbcca67'
+        AND tx_status = 'SUCCESS'
+
+{% if is_incremental() %}
+AND _inserted_timestamp >= (
+    SELECT
+        MAX(_inserted_timestamp) :: DATE
+    FROM
+        {{ this }}
+)
+{% endif %}
+)
+SELECT
+    block_number,
+    block_timestamp,
+    origin_function_signature,
+    origin_from_address,
+    origin_to_address,
+    tx_hash,
+    event_index,
+    contract_address,
+    sender_address AS sender,
+    reipient_address AS tx_to,
+    amount0,
+    amount1,
+    price,
+    liquidity,
+    tick,
+    amountIn AS amount_in_unadj,
+    amountOut AS amount_out_unadj,
+    token_in,
+    token_out,
+    'Swap' AS event_name,
+    'camelot-v3' AS platform,
+    _log_id,
+    _inserted_timestamp
+FROM
+    swaps_base

--- a/models/silver/dex/camelot/silver_dex__camelot_v3_swaps.sql
+++ b/models/silver/dex/camelot/silver_dex__camelot_v3_swaps.sql
@@ -69,7 +69,7 @@ swaps_base AS (
         _log_id,
         _inserted_timestamp
     FROM
-        {{ ref('silver__logs2') }} l
+        {{ ref('silver__logs') }} l
         INNER JOIN pools p
         ON p.pool_address = contract_address
     WHERE

--- a/models/silver/dex/camelot/silver_dex__camelot_v3_swaps.yml
+++ b/models/silver/dex/camelot/silver_dex__camelot_v3_swaps.yml
@@ -1,0 +1,116 @@
+version: 2
+models:
+  - name: silver_dex__camelot_v3_swaps
+
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - _LOG_ID
+    columns:
+      - name: BLOCK_NUMBER
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - FLOAT
+      - name: BLOCK_TIMESTAMP
+        tests:
+          - not_null
+          - dbt_expectations.expect_row_values_to_have_recent_data:
+              datepart: day
+              interval: 2
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - TIMESTAMP_LTZ
+                - TIMESTAMP_NTZ
+      - name: TX_HASH
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: CONTRACT_ADDRESS
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: AMOUNT_IN_UNADJ
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - FLOAT
+      - name: AMOUNT_IN
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - FLOAT
+      - name: AMOUNT_OUT_UNADJ
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - FLOAT
+      - name: AMOUNT_OUT
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - FLOAT
+      - name: TOKEN_IN
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+
+      - name: TOKEN_OUT
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: SYMBOL_IN
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - STRING
+                - VARCHAR
+      - name: SYMBOL_OUT
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - STRING
+                - VARCHAR
+      - name: TX_TO
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: PLATFORM
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - STRING
+                - VARCHAR
+      - name: EVENT_INDEX
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - FLOAT
+      - name: _LOG_ID
+        tests:
+          - not_null
+      - name: ORIGIN_FUNCTION_SIGNATURE
+        tests:
+          - not_null
+      - name: ORIGIN_FROM_ADDRESS
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: ORIGIN_TO_ADDRESS
+        tests:
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+

--- a/models/silver/dex/curve/silver_dex__curve_pools.sql
+++ b/models/silver/dex/curve/silver_dex__curve_pools.sql
@@ -2,34 +2,31 @@
     materialized = 'incremental',
     unique_key = "pool_id",
 ) }}
---    full_refresh = false
+-- full_refresh = false
+
 WITH contract_deployments AS (
 
-    SELECT
-        tx_hash,
-        block_number,
-        block_timestamp,
-        from_address AS deployer_address,
-        to_address AS contract_address,
-        _inserted_timestamp,
-        ROW_NUMBER() over (
-            ORDER BY
-                contract_address
-        ) AS row_num
-    FROM
-        {{ ref('silver__traces') }}
-    WHERE
-        -- curve contract deployers
-        from_address IN (
-            '0x7eeac6cddbd1d0b8af061742d41877d7f707289a',
-            '0x745748bcfd8f9c2de519a71d789be8a63dd7d66c',
-            '0xbabe61887f1de2713c6f97e567623453d3c79f67',
-            '0xb17b674d9c5cb2e441f8e196a2f048a81355d031'
+SELECT
+    tx_hash,
+    block_number,
+    block_timestamp,
+    from_address AS deployer_address,
+    to_address AS contract_address,
+    _inserted_timestamp,
+    ROW_NUMBER() OVER (ORDER BY contract_address) AS row_num
+FROM
+    {{ ref('silver__traces' )}}
+WHERE 
+    -- curve contract deployers
+    from_address IN (
+        '0x7eeac6cddbd1d0b8af061742d41877d7f707289a',
+        '0x745748bcfd8f9c2de519a71d789be8a63dd7d66c',
+        '0xbabe61887f1de2713c6f97e567623453d3c79f67',
+        '0xb17b674d9c5cb2e441f8e196a2f048a81355d031'
         )
-        AND TYPE ILIKE 'create%'
-        AND tx_status ILIKE 'success'
-        AND trace_status ILIKE 'success'
-
+    AND TYPE ILIKE 'create%'
+    AND TX_STATUS ILIKE 'SUCCESS'
+    AND TRACE_STATUS ILIKE 'SUCCESS'
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
@@ -44,226 +41,304 @@ AND to_address NOT IN (
         {{ this }}
 )
 {% endif %}
+QUALIFY(ROW_NUMBER() OVER(PARTITION BY to_address ORDER BY block_timestamp ASC)) = 1
+),
 
-qualify(ROW_NUMBER() over(PARTITION BY to_address
-ORDER BY
-    block_timestamp ASC)) = 1
-),
 function_sigs AS (
-    SELECT
-        '0x87cb4f57' AS function_sig,
-        'base_coins' AS function_name
-    UNION ALL
-    SELECT
-        '0xb9947eb0' AS function_sig,
-        'underlying_coins' AS function_name
-    UNION ALL
-    SELECT
-        '0xc6610657' AS function_sig,
-        'coins' AS function_name
-    UNION ALL
-    SELECT
-        '0x06fdde03' AS function_sig,
-        'name' AS function_name
-    UNION ALL
-    SELECT
-        '0x95d89b41' AS function_sig,
-        'symbol' AS function_name
-    UNION ALL
-    SELECT
-        '0x313ce567' AS function_sig,
-        'decimals' AS function_name
+
+SELECT
+	'0x87cb4f57' AS function_sig,
+    'base_coins' AS function_name
+UNION ALL
+SELECT
+	'0xb9947eb0' AS function_sig,
+    'underlying_coins' AS function_name
+UNION ALL
+SELECT
+    '0xc6610657' AS function_sig, 
+    'coins' AS function_name
+UNION ALL
+SELECT
+    '0x06fdde03' AS function_sig, 
+    'name' AS function_name
+UNION ALL
+SELECT
+    '0x95d89b41' AS function_sig, 
+    'symbol' AS function_name
+UNION ALL
+SELECT
+    '0x313ce567' AS function_sig, 
+    'decimals' AS function_name
 ),
+
 function_inputs AS (
     SELECT
         SEQ4() AS function_input
     FROM
         TABLE(GENERATOR(rowcount => 8))
 ),
+
 inputs_coins AS (
-    SELECT
-        deployer_address,
-        contract_address,
-        block_number,
-        function_sig,
-        (ROW_NUMBER() over (PARTITION BY contract_address
-    ORDER BY
-        block_number)) - 1 AS function_input
-    FROM
-        contract_deployments
-        JOIN function_sigs
-        ON 1 = 1
-        JOIN function_inputs
-        ON 1 = 1
-    WHERE
-        function_name = 'coins'
+
+SELECT
+    deployer_address,
+    contract_address,
+    block_number,
+    function_sig,
+    (ROW_NUMBER() OVER (PARTITION BY contract_address
+        ORDER BY block_number)) - 1 AS function_input
+FROM contract_deployments
+JOIN function_sigs ON 1=1
+JOIN function_inputs ON 1=1
+    WHERE function_name = 'coins'
 ),
+
 inputs_base_coins AS (
-    SELECT
-        deployer_address,
-        contract_address,
-        block_number,
-        function_sig,
-        (ROW_NUMBER() over (PARTITION BY contract_address
-    ORDER BY
-        block_number)) - 1 AS function_input
-    FROM
-        contract_deployments
-        JOIN function_sigs
-        ON 1 = 1
-        JOIN function_inputs
-        ON 1 = 1
-    WHERE
-        function_name = 'base_coins'
+
+SELECT
+    deployer_address,
+    contract_address,
+    block_number,
+    function_sig,
+    (ROW_NUMBER() OVER (PARTITION BY contract_address
+        ORDER BY block_number)) - 1 AS function_input
+FROM contract_deployments
+JOIN function_sigs ON 1=1
+JOIN function_inputs ON 1=1
+    WHERE function_name = 'base_coins'
 ),
+
 inputs_underlying_coins AS (
-    SELECT
-        deployer_address,
-        contract_address,
-        block_number,
-        function_sig,
-        (ROW_NUMBER() over (PARTITION BY contract_address
-    ORDER BY
-        block_number)) - 1 AS function_input
-    FROM
-        contract_deployments
-        JOIN function_sigs
-        ON 1 = 1
-        JOIN function_inputs
-        ON 1 = 1
-    WHERE
-        function_name = 'underlying_coins'
+
+SELECT
+    deployer_address,
+    contract_address,
+    block_number,
+    function_sig,
+    (ROW_NUMBER() OVER (PARTITION BY contract_address
+        ORDER BY block_number)) - 1 AS function_input
+FROM contract_deployments
+JOIN function_sigs ON 1=1
+JOIN function_inputs ON 1=1
+    WHERE function_name = 'underlying_coins'
 ),
+
 inputs_pool_details AS (
-    SELECT
-        deployer_address,
-        contract_address,
-        block_number,
-        function_sig,
-        NULL AS function_input
-    FROM
-        contract_deployments
-        JOIN function_sigs
-        ON 1 = 1
-    WHERE
-        function_name IN (
-            'name',
-            'symbol',
-            'decimals'
-        )
+
+SELECT
+    deployer_address,
+    contract_address,
+    block_number,
+    function_sig,
+    NULL AS function_input
+FROM contract_deployments
+JOIN function_sigs ON 1=1
+WHERE function_name IN ('name','symbol','decimals')
 ),
+
 all_inputs AS (
-    SELECT
-        deployer_address,
-        contract_address,
-        block_number,
-        function_sig,
-        function_input
-    FROM
-        inputs_coins
-    UNION ALL
-    SELECT
-        deployer_address,
-        contract_address,
-        block_number,
-        function_sig,
-        function_input
-    FROM
-        inputs_base_coins
-    UNION ALL
-    SELECT
-        deployer_address,
-        contract_address,
-        block_number,
-        function_sig,
-        function_input
-    FROM
-        inputs_underlying_coins
-    UNION ALL
-    SELECT
-        deployer_address,
-        contract_address,
-        block_number,
-        function_sig,
-        function_input
-    FROM
-        inputs_pool_details
+
+SELECT
+    deployer_address,
+    contract_address,
+    block_number,
+    function_sig,
+    function_input
+FROM inputs_coins
+UNION ALL
+SELECT
+    deployer_address,
+    contract_address,
+    block_number,
+    function_sig,
+    function_input
+FROM inputs_base_coins
+UNION ALL
+SELECT
+    deployer_address,
+    contract_address,
+    block_number,
+    function_sig,
+    function_input
+FROM inputs_underlying_coins
+UNION ALL
+SELECT
+    deployer_address,
+    contract_address,
+    block_number,
+    function_sig,
+    function_input
+FROM inputs_pool_details
 ),
-pool_token_reads AS ({% for item in range(5) %}
-    (
+
+pool_token_reads AS (
+
+{% for item in range(5) %}
+(
 SELECT
-    ethereum.streamline.udf_json_rpc_read_calls(node_url, headers, PARSE_JSON(batch_read)) AS read_output, SYSDATE() AS _inserted_timestamp
-FROM
-    (
+    ethereum.streamline.udf_json_rpc_read_calls(
+        node_url,
+        headers,
+        PARSE_JSON(batch_read)
+    ) AS read_output,
+    SYSDATE() AS _inserted_timestamp
+FROM (
+    SELECT
+        CONCAT('[', LISTAGG(read_input, ','), ']') AS batch_read
+    FROM (
+        SELECT 
+            deployer_address,
+            contract_address,
+            block_number,
+            function_sig,
+            function_input,
+            CONCAT(
+                '[\'',
+                contract_address,
+                '\',',
+                block_number,
+                ',\'',
+                function_sig,
+                '\',\'',
+                (CASE WHEN function_input IS NULL THEN '' ELSE function_input::STRING END),
+                '\']'
+                ) AS read_input,
+                row_num
+        FROM all_inputs
+        LEFT JOIN contract_deployments USING(contract_address) 
+            ) ready_reads_pools
+    WHERE row_num BETWEEN {{ item * 500 + 1 }} AND {{ (item + 1) * 500}}
+    ) batch_reads_pools
+JOIN {{ source(
+            'streamline_crosschain',
+            'node_mapping'
+        ) }} ON 1=1 
+    AND chain = 'arbitrum'
+) {% if not loop.last %}
+UNION ALL
+{% endif %}
+{% endfor %}
+),
+
+reads_adjusted AS (
+    
 SELECT
-    CONCAT('[', LISTAGG(read_input, ','), ']') AS batch_read
+        VALUE :id :: STRING AS read_id,
+        VALUE :result :: STRING AS read_result,
+        SPLIT(
+            read_id,
+            '-'
+        ) AS read_id_object,
+        read_id_object [0] :: STRING AS contract_address,
+        read_id_object [1] :: STRING AS block_number,
+        read_id_object [2] :: STRING AS function_sig,
+        read_id_object [3] :: STRING AS function_input,
+        _inserted_timestamp
 FROM
-    (
+    pool_token_reads,
+    LATERAL FLATTEN(
+        input => read_output [0] :data
+    ) 
+),
+
+tokens AS (
+    
 SELECT
-    deployer_address, contract_address, block_number, function_sig, function_input, CONCAT('[\'', contract_address, '\',', block_number, ',\'', function_sig, '\',\'', (CASE
-    WHEN function_input IS NULL THEN ''
-    ELSE function_input :: stringend), '\']') AS read_input, row_num
-FROM
-    all_inputs
-    LEFT JOIN contract_deployments USING(contract_address)) ready_reads_pools
-WHERE
-    row_num BETWEEN {{ item * 500 + 1 }}
-    AND {{(item + 1) * 500 }}) batch_reads_pools
-    JOIN {{ source('streamline_crosschain', 'node_mapping') }}
-    ON 1 = 1
-    AND chain = 'arbitrum') {% if not loop.last %}
-    UNION ALL
-    {% endif %}
-{% endfor %}), reads_adjusted AS (
+    contract_address,
+    function_sig,
+    function_name,
+    function_input,
+    read_result,
+    regexp_substr_all(SUBSTR(read_result, 3, len(read_result)), '.{64}')[0]AS segmented_token_address,
+    _inserted_timestamp
+FROM reads_adjusted
+LEFT JOIN function_sigs USING(function_sig)
+WHERE function_name IN ('coins','base_coins','underlying_coins')
+    AND read_result IS NOT NULL
+    
+),
+
+pool_details AS (
+
 SELECT
-    VALUE :id :: STRING AS read_id, VALUE :result :: STRING AS read_result, SPLIT(read_id, '-') AS read_id_object, read_id_object [0] :: STRING AS contract_address, read_id_object [1] :: STRING AS block_number, read_id_object [2] :: STRING AS function_sig, read_id_object [3] :: STRING AS function_input, _inserted_timestamp
-FROM
-    pool_token_reads, LATERAL FLATTEN(input => read_output [0] :data)), tokens AS (
+    contract_address,
+    function_sig,
+    function_name,
+    function_input,
+    read_result,
+    regexp_substr_all(SUBSTR(read_result, 3, len(read_result)), '.{64}') AS segmented_output,
+    _inserted_timestamp
+FROM reads_adjusted
+LEFT JOIN function_sigs USING(function_sig)
+WHERE function_name IN ('name','symbol','decimals')
+    AND read_result IS NOT NULL
+
+),
+
+all_pools AS (
 SELECT
-    contract_address, function_sig, function_name, function_input, read_result, regexp_substr_all(SUBSTR(read_result, 3, len(read_result)), '.{64}') [0] AS segmented_token_address, _inserted_timestamp
-FROM
-    reads_adjusted
-    LEFT JOIN function_sigs USING(function_sig)
-WHERE
-    function_name IN ('coins', 'base_coins', 'underlying_coins')
-    AND read_result IS NOT NULL), pool_details AS (
-SELECT
-    contract_address, function_sig, function_name, function_input, read_result, regexp_substr_all(SUBSTR(read_result, 3, len(read_result)), '.{64}') AS segmented_output, _inserted_timestamp
-FROM
-    reads_adjusted
-    LEFT JOIN function_sigs USING(function_sig)
-WHERE
-    function_name IN ('name', 'symbol', 'decimals')
-    AND read_result IS NOT NULL), all_pools AS (
-SELECT
-    t.contract_address AS pool_address, CONCAT('0x', SUBSTRING(t.segmented_token_address, 25, 40)) AS token_address, function_input AS token_id, function_name AS token_type, MIN(CASE
-    WHEN p.function_name = 'symbol' THEN TRY_HEX_DECODE_STRING(RTRIM(p.segmented_output [2] :: STRING, 0))END) AS pool_symbol, MIN(CASE
-    WHEN p.function_name = 'name' THEN CONCAT(TRY_HEX_DECODE_STRING(p.segmented_output [2] :: STRING), TRY_HEX_DECODE_STRING(segmented_output [3] :: STRING))END) AS pool_name, MIN(CASE
-    WHEN p.read_result :: STRING = '0x' THEN NULL
-    ELSE utils.udf_hex_to_int(LEFT(p.read_result :: STRING, 66))END) :: INTEGER AS pool_decimals, CONCAT(t.contract_address, '-', CONCAT('0x', SUBSTRING(t.segmented_token_address, 25, 40)), '-', function_input, '-', function_name) AS pool_id, MAX(t._inserted_timestamp) AS _inserted_timestamp
-FROM
-    tokens t
-    LEFT JOIN pool_details p USING(contract_address)
-WHERE
-    token_address IS NOT NULL
+    t.contract_address AS pool_address,
+    CONCAT('0x',SUBSTRING(t.segmented_token_address,25,40)) AS token_address,
+    function_input AS token_id,
+    function_name AS token_type,
+    MIN(CASE WHEN p.function_name = 'symbol' THEN TRY_HEX_DECODE_STRING(RTRIM(p.segmented_output [2] :: STRING, 0)) END) AS pool_symbol,
+    MIN(CASE WHEN p.function_name = 'name' THEN CONCAT(TRY_HEX_DECODE_STRING(p.segmented_output [2] :: STRING),
+        TRY_HEX_DECODE_STRING(segmented_output [3] :: STRING)) END) AS pool_name,
+    MIN(CASE 
+            WHEN p.read_result::STRING = '0x' THEN NULL
+            ELSE ethereum.public.udf_hex_to_int(LEFT(p.read_result::STRING,66))
+        END)::INTEGER  AS pool_decimals,
+    CONCAT(
+        t.contract_address,
+        '-',
+        CONCAT('0x',SUBSTRING(t.segmented_token_address,25,40)),
+        '-',
+        function_input,
+        '-',
+        function_name
+    ) AS pool_id,
+    MAX(t._inserted_timestamp) AS _inserted_timestamp
+FROM tokens t
+LEFT JOIN pool_details p USING(contract_address)
+WHERE token_address IS NOT NULL 
     AND token_address <> '0x0000000000000000000000000000000000000000'
-GROUP BY
-    1, 2, 3, 4), FINAL AS (
+GROUP BY 1,2,3,4
+),
+
+FINAL AS (
 SELECT
-    pool_address, CASE
-    WHEN token_address = '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee' THEN '0x82af49447d8a07e3bd95bd0d56f35241523fbab1'
-    ELSE token_addressEND AS token_address, token_id, token_type, CASE
-    WHEN token_address = '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee' THEN 'WETH'
-    WHEN pool_symbol IS NULL THEN C.token_symbol
-    ELSE pool_symbolEND AS pool_symbol, pool_name, CASE
-    WHEN token_address = '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee' THEN '18'
-    WHEN pool_decimals IS NULL THEN C.token_decimals
-    ELSE pool_decimalsEND AS pool_decimals, pool_id, A._inserted_timestamp
-FROM
-    all_pools A
-    LEFT JOIN {{ ref('silver__contracts') }} C
-    ON A.token_address = C.contract_address)
+    pool_address,
+    CASE
+        WHEN token_address = '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee' THEN '0x82af49447d8a07e3bd95bd0d56f35241523fbab1'
+        ELSE token_address
+    END AS token_address,
+    token_id,
+    token_type,
+    CASE 
+        WHEN token_address = '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee' THEN 'WETH'
+        WHEN pool_symbol IS NULL THEN c.token_symbol
+        ELSE pool_symbol
+    END AS pool_symbol,
+    pool_name,
+    CASE 
+        WHEN token_address = '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee' THEN '18'
+    	WHEN pool_decimals IS NULL THEN c.token_decimals
+        ELSE pool_decimals
+    END AS pool_decimals,
+    pool_id,
+    a._inserted_timestamp
+FROM all_pools a
+LEFT JOIN {{ ref('silver__contracts') }} c ON a.token_address = c.contract_address
+)
+
 SELECT
-    pool_address, token_address, token_id, token_type, pool_symbol, pool_name, pool_decimals, pool_id, _inserted_timestamp
-FROM
-    FINAL
+    pool_address,
+    token_address,
+    token_id,
+    token_type,
+    pool_symbol,
+    pool_name,
+    pool_decimals,
+    pool_id,
+    _inserted_timestamp
+FROM FINAL

--- a/models/silver/dex/curve/silver_dex__curve_pools.sql
+++ b/models/silver/dex/curve/silver_dex__curve_pools.sql
@@ -173,7 +173,7 @@ FROM inputs_pool_details
 
 pool_token_reads AS (
 
-{% for item in range(5) %}
+{% for item in range(20) %}
 (
 SELECT
     ethereum.streamline.udf_json_rpc_read_calls(
@@ -207,7 +207,7 @@ FROM (
         FROM all_inputs
         LEFT JOIN contract_deployments USING(contract_address) 
             ) ready_reads_pools
-    WHERE row_num BETWEEN {{ item * 500 + 1 }} AND {{ (item + 1) * 500}}
+    WHERE row_num BETWEEN {{ item * 50 + 1 }} AND {{ (item + 1) * 50}}
     ) batch_reads_pools
 JOIN {{ source(
             'streamline_crosschain',

--- a/models/silver/dex/curve/silver_dex__curve_pools.sql
+++ b/models/silver/dex/curve/silver_dex__curve_pools.sql
@@ -1,0 +1,343 @@
+{{ config(
+    materialized = 'incremental',
+    unique_key = "pool_id",
+    full_refresh = false
+) }}
+
+WITH contract_deployments AS (
+
+SELECT
+    tx_hash,
+    block_number,
+    block_timestamp,
+    from_address AS deployer_address,
+    to_address AS contract_address,
+    _inserted_timestamp,
+    ROW_NUMBER() OVER (ORDER BY contract_address) AS row_num
+FROM
+    {{ ref('silver__traces2' )}}
+WHERE 
+    -- curve contract deployers
+    from_address IN (
+        '0x7eeac6cddbd1d0b8af061742d41877d7f707289a',
+        '0x745748bcfd8f9c2de519a71d789be8a63dd7d66c',
+        '0xbabe61887f1de2713c6f97e567623453d3c79f67',
+        '0xb17b674d9c5cb2e441f8e196a2f048a81355d031'
+        )
+    AND TYPE ilike 'create%'
+    AND TX_STATUS ilike 'success'
+{% if is_incremental() %}
+AND _inserted_timestamp >= (
+    SELECT
+        MAX(_inserted_timestamp) :: DATE - 3
+    FROM
+        {{ this }}
+)
+AND to_address NOT IN (
+    SELECT
+        DISTINCT pool_address
+    FROM
+        {{ this }}
+)
+{% endif %}
+QUALIFY(ROW_NUMBER() OVER(PARTITION BY to_address ORDER BY block_timestamp ASC)) = 1
+),
+
+function_sigs AS (
+
+SELECT
+	'0x87cb4f57' AS function_sig,
+    'base_coins' AS function_name
+UNION ALL
+SELECT
+	'0xb9947eb0' AS function_sig,
+    'underlying_coins' AS function_name
+UNION ALL
+SELECT
+    '0xc6610657' AS function_sig, 
+    'coins' AS function_name
+UNION ALL
+SELECT
+    '0x06fdde03' AS function_sig, 
+    'name' AS function_name
+UNION ALL
+SELECT
+    '0x95d89b41' AS function_sig, 
+    'symbol' AS function_name
+UNION ALL
+SELECT
+    '0x313ce567' AS function_sig, 
+    'decimals' AS function_name
+),
+
+function_inputs AS (
+    SELECT
+        SEQ4() AS function_input
+    FROM
+        TABLE(GENERATOR(rowcount => 8))
+),
+
+inputs_coins AS (
+
+SELECT
+    deployer_address,
+    contract_address,
+    block_number,
+    function_sig,
+    (ROW_NUMBER() OVER (PARTITION BY contract_address
+        ORDER BY block_number)) - 1 AS function_input
+FROM contract_deployments
+JOIN function_sigs ON 1=1
+JOIN function_inputs ON 1=1
+    WHERE function_name = 'coins'
+),
+
+inputs_base_coins AS (
+
+SELECT
+    deployer_address,
+    contract_address,
+    block_number,
+    function_sig,
+    (ROW_NUMBER() OVER (PARTITION BY contract_address
+        ORDER BY block_number)) - 1 AS function_input
+FROM contract_deployments
+JOIN function_sigs ON 1=1
+JOIN function_inputs ON 1=1
+    WHERE function_name = 'base_coins'
+),
+
+inputs_underlying_coins AS (
+
+SELECT
+    deployer_address,
+    contract_address,
+    block_number,
+    function_sig,
+    (ROW_NUMBER() OVER (PARTITION BY contract_address
+        ORDER BY block_number)) - 1 AS function_input
+FROM contract_deployments
+JOIN function_sigs ON 1=1
+JOIN function_inputs ON 1=1
+    WHERE function_name = 'underlying_coins'
+),
+
+inputs_pool_details AS (
+
+SELECT
+    deployer_address,
+    contract_address,
+    block_number,
+    function_sig,
+    NULL AS function_input
+FROM contract_deployments
+JOIN function_sigs ON 1=1
+WHERE function_name IN ('name','symbol','decimals')
+),
+
+all_inputs AS (
+
+SELECT
+    deployer_address,
+    contract_address,
+    block_number,
+    function_sig,
+    function_input
+FROM inputs_coins
+UNION ALL
+SELECT
+    deployer_address,
+    contract_address,
+    block_number,
+    function_sig,
+    function_input
+FROM inputs_base_coins
+UNION ALL
+SELECT
+    deployer_address,
+    contract_address,
+    block_number,
+    function_sig,
+    function_input
+FROM inputs_underlying_coins
+UNION ALL
+SELECT
+    deployer_address,
+    contract_address,
+    block_number,
+    function_sig,
+    function_input
+FROM inputs_pool_details
+),
+
+pool_token_reads AS (
+
+{% for item in range(5) %}
+(
+SELECT
+    ethereum.streamline.udf_json_rpc_read_calls(
+        node_url,
+        headers,
+        PARSE_JSON(batch_read)
+    ) AS read_output,
+    SYSDATE() AS _inserted_timestamp
+FROM (
+    SELECT
+        CONCAT('[', LISTAGG(read_input, ','), ']') AS batch_read
+    FROM (
+        SELECT 
+            deployer_address,
+            contract_address,
+            block_number,
+            function_sig,
+            function_input,
+            CONCAT(
+                '[\'',
+                contract_address,
+                '\',',
+                block_number,
+                ',\'',
+                function_sig,
+                '\',\'',
+                (CASE WHEN function_input IS NULL THEN '' ELSE function_input::STRING END),
+                '\']'
+                ) AS read_input,
+                row_num
+        FROM all_inputs
+        LEFT JOIN contract_deployments USING(contract_address) 
+            ) ready_reads_pools
+    WHERE row_num BETWEEN {{ item * 500 + 1 }} AND {{ (item + 1) * 500}}
+    ) batch_reads_pools
+JOIN {{ source(
+            'streamline_crosschain',
+            'node_mapping'
+        ) }} ON 1=1 
+    AND chain = 'arbitrum'
+) {% if not loop.last %}
+UNION ALL
+{% endif %}
+{% endfor %}
+),
+
+reads_adjusted AS (
+    
+SELECT
+        VALUE :id :: STRING AS read_id,
+        VALUE :result :: STRING AS read_result,
+        SPLIT(
+            read_id,
+            '-'
+        ) AS read_id_object,
+        read_id_object [0] :: STRING AS contract_address,
+        read_id_object [1] :: STRING AS block_number,
+        read_id_object [2] :: STRING AS function_sig,
+        read_id_object [3] :: STRING AS function_input,
+        _inserted_timestamp
+FROM
+    pool_token_reads,
+    LATERAL FLATTEN(
+        input => read_output [0] :data
+    ) 
+),
+
+tokens AS (
+    
+SELECT
+    contract_address,
+    function_sig,
+    function_name,
+    function_input,
+    read_result,
+    regexp_substr_all(SUBSTR(read_result, 3, len(read_result)), '.{64}')[0]AS segmented_token_address,
+    _inserted_timestamp
+FROM reads_adjusted
+LEFT JOIN function_sigs USING(function_sig)
+WHERE function_name IN ('coins','base_coins','underlying_coins')
+    AND read_result IS NOT NULL
+    
+),
+
+pool_details AS (
+
+SELECT
+    contract_address,
+    function_sig,
+    function_name,
+    function_input,
+    read_result,
+    regexp_substr_all(SUBSTR(read_result, 3, len(read_result)), '.{64}') AS segmented_output,
+    _inserted_timestamp
+FROM reads_adjusted
+LEFT JOIN function_sigs USING(function_sig)
+WHERE function_name IN ('name','symbol','decimals')
+    AND read_result IS NOT NULL
+
+),
+
+all_pools AS (
+SELECT
+    t.contract_address AS pool_address,
+    CONCAT('0x',SUBSTRING(t.segmented_token_address,25,40)) AS token_address,
+    function_input AS token_id,
+    function_name AS token_type,
+    MIN(CASE WHEN p.function_name = 'symbol' THEN TRY_HEX_DECODE_STRING(RTRIM(p.segmented_output [2] :: STRING, 0)) END) AS pool_symbol,
+    MIN(CASE WHEN p.function_name = 'name' THEN CONCAT(TRY_HEX_DECODE_STRING(p.segmented_output [2] :: STRING),
+        TRY_HEX_DECODE_STRING(segmented_output [3] :: STRING)) END) AS pool_name,
+    MIN(CASE 
+            WHEN p.read_result::STRING = '0x' THEN NULL
+            ELSE utils.udf_hex_to_int(LEFT(p.read_result::STRING,66))
+        END)::INTEGER  AS pool_decimals,
+    CONCAT(
+        t.contract_address,
+        '-',
+        CONCAT('0x',SUBSTRING(t.segmented_token_address,25,40)),
+        '-',
+        function_input,
+        '-',
+        function_name
+    ) AS pool_id,
+    MAX(t._inserted_timestamp) AS _inserted_timestamp
+FROM tokens t
+LEFT JOIN pool_details p USING(contract_address)
+WHERE token_address IS NOT NULL 
+    AND token_address <> '0x0000000000000000000000000000000000000000'
+GROUP BY 1,2,3,4
+),
+
+FINAL AS (
+SELECT
+    pool_address,
+    CASE
+        WHEN token_address = '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee' THEN '0x82af49447d8a07e3bd95bd0d56f35241523fbab1'
+        ELSE token_address
+    END AS token_address,
+    token_id,
+    token_type,
+    CASE 
+        WHEN token_address = '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee' THEN 'WETH'
+        WHEN pool_symbol IS NULL THEN c.token_symbol
+        ELSE pool_symbol
+    END AS pool_symbol,
+    pool_name,
+    CASE 
+        WHEN token_address = '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee' THEN '18'
+    	WHEN pool_decimals IS NULL THEN c.token_decimals
+        ELSE pool_decimals
+    END AS pool_decimals,
+    pool_id,
+    a._inserted_timestamp
+FROM all_pools a
+LEFT JOIN {{ ref('silver__contracts') }} c ON a.token_address = c.contract_address
+)
+
+SELECT
+    pool_address,
+    token_address,
+    token_id,
+    token_type,
+    pool_symbol,
+    pool_name,
+    pool_decimals,
+    pool_id,
+    _inserted_timestamp
+FROM FINAL

--- a/models/silver/dex/curve/silver_dex__curve_pools.sql
+++ b/models/silver/dex/curve/silver_dex__curve_pools.sql
@@ -15,7 +15,7 @@ SELECT
     _inserted_timestamp,
     ROW_NUMBER() OVER (ORDER BY contract_address) AS row_num
 FROM
-    {{ ref('silver__traces2' )}}
+    {{ ref('silver__traces' )}}
 WHERE 
     -- curve contract deployers
     from_address IN (

--- a/models/silver/dex/curve/silver_dex__curve_pools.sql
+++ b/models/silver/dex/curve/silver_dex__curve_pools.sql
@@ -1,31 +1,35 @@
 {{ config(
     materialized = 'incremental',
     unique_key = "pool_id",
-    full_refresh = false
 ) }}
-
+--    full_refresh = false
 WITH contract_deployments AS (
 
-SELECT
-    tx_hash,
-    block_number,
-    block_timestamp,
-    from_address AS deployer_address,
-    to_address AS contract_address,
-    _inserted_timestamp,
-    ROW_NUMBER() OVER (ORDER BY contract_address) AS row_num
-FROM
-    {{ ref('silver__traces' )}}
-WHERE 
-    -- curve contract deployers
-    from_address IN (
-        '0x7eeac6cddbd1d0b8af061742d41877d7f707289a',
-        '0x745748bcfd8f9c2de519a71d789be8a63dd7d66c',
-        '0xbabe61887f1de2713c6f97e567623453d3c79f67',
-        '0xb17b674d9c5cb2e441f8e196a2f048a81355d031'
+    SELECT
+        tx_hash,
+        block_number,
+        block_timestamp,
+        from_address AS deployer_address,
+        to_address AS contract_address,
+        _inserted_timestamp,
+        ROW_NUMBER() over (
+            ORDER BY
+                contract_address
+        ) AS row_num
+    FROM
+        {{ ref('silver__traces') }}
+    WHERE
+        -- curve contract deployers
+        from_address IN (
+            '0x7eeac6cddbd1d0b8af061742d41877d7f707289a',
+            '0x745748bcfd8f9c2de519a71d789be8a63dd7d66c',
+            '0xbabe61887f1de2713c6f97e567623453d3c79f67',
+            '0xb17b674d9c5cb2e441f8e196a2f048a81355d031'
         )
-    AND TYPE ilike 'create%'
-    AND TX_STATUS ilike 'success'
+        AND TYPE ILIKE 'create%'
+        AND tx_status ILIKE 'success'
+        AND trace_status ILIKE 'success'
+
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
     SELECT
@@ -40,304 +44,226 @@ AND to_address NOT IN (
         {{ this }}
 )
 {% endif %}
-QUALIFY(ROW_NUMBER() OVER(PARTITION BY to_address ORDER BY block_timestamp ASC)) = 1
-),
 
+qualify(ROW_NUMBER() over(PARTITION BY to_address
+ORDER BY
+    block_timestamp ASC)) = 1
+),
 function_sigs AS (
-
-SELECT
-	'0x87cb4f57' AS function_sig,
-    'base_coins' AS function_name
-UNION ALL
-SELECT
-	'0xb9947eb0' AS function_sig,
-    'underlying_coins' AS function_name
-UNION ALL
-SELECT
-    '0xc6610657' AS function_sig, 
-    'coins' AS function_name
-UNION ALL
-SELECT
-    '0x06fdde03' AS function_sig, 
-    'name' AS function_name
-UNION ALL
-SELECT
-    '0x95d89b41' AS function_sig, 
-    'symbol' AS function_name
-UNION ALL
-SELECT
-    '0x313ce567' AS function_sig, 
-    'decimals' AS function_name
+    SELECT
+        '0x87cb4f57' AS function_sig,
+        'base_coins' AS function_name
+    UNION ALL
+    SELECT
+        '0xb9947eb0' AS function_sig,
+        'underlying_coins' AS function_name
+    UNION ALL
+    SELECT
+        '0xc6610657' AS function_sig,
+        'coins' AS function_name
+    UNION ALL
+    SELECT
+        '0x06fdde03' AS function_sig,
+        'name' AS function_name
+    UNION ALL
+    SELECT
+        '0x95d89b41' AS function_sig,
+        'symbol' AS function_name
+    UNION ALL
+    SELECT
+        '0x313ce567' AS function_sig,
+        'decimals' AS function_name
 ),
-
 function_inputs AS (
     SELECT
         SEQ4() AS function_input
     FROM
         TABLE(GENERATOR(rowcount => 8))
 ),
-
 inputs_coins AS (
-
-SELECT
-    deployer_address,
-    contract_address,
-    block_number,
-    function_sig,
-    (ROW_NUMBER() OVER (PARTITION BY contract_address
-        ORDER BY block_number)) - 1 AS function_input
-FROM contract_deployments
-JOIN function_sigs ON 1=1
-JOIN function_inputs ON 1=1
-    WHERE function_name = 'coins'
-),
-
-inputs_base_coins AS (
-
-SELECT
-    deployer_address,
-    contract_address,
-    block_number,
-    function_sig,
-    (ROW_NUMBER() OVER (PARTITION BY contract_address
-        ORDER BY block_number)) - 1 AS function_input
-FROM contract_deployments
-JOIN function_sigs ON 1=1
-JOIN function_inputs ON 1=1
-    WHERE function_name = 'base_coins'
-),
-
-inputs_underlying_coins AS (
-
-SELECT
-    deployer_address,
-    contract_address,
-    block_number,
-    function_sig,
-    (ROW_NUMBER() OVER (PARTITION BY contract_address
-        ORDER BY block_number)) - 1 AS function_input
-FROM contract_deployments
-JOIN function_sigs ON 1=1
-JOIN function_inputs ON 1=1
-    WHERE function_name = 'underlying_coins'
-),
-
-inputs_pool_details AS (
-
-SELECT
-    deployer_address,
-    contract_address,
-    block_number,
-    function_sig,
-    NULL AS function_input
-FROM contract_deployments
-JOIN function_sigs ON 1=1
-WHERE function_name IN ('name','symbol','decimals')
-),
-
-all_inputs AS (
-
-SELECT
-    deployer_address,
-    contract_address,
-    block_number,
-    function_sig,
-    function_input
-FROM inputs_coins
-UNION ALL
-SELECT
-    deployer_address,
-    contract_address,
-    block_number,
-    function_sig,
-    function_input
-FROM inputs_base_coins
-UNION ALL
-SELECT
-    deployer_address,
-    contract_address,
-    block_number,
-    function_sig,
-    function_input
-FROM inputs_underlying_coins
-UNION ALL
-SELECT
-    deployer_address,
-    contract_address,
-    block_number,
-    function_sig,
-    function_input
-FROM inputs_pool_details
-),
-
-pool_token_reads AS (
-
-{% for item in range(5) %}
-(
-SELECT
-    ethereum.streamline.udf_json_rpc_read_calls(
-        node_url,
-        headers,
-        PARSE_JSON(batch_read)
-    ) AS read_output,
-    SYSDATE() AS _inserted_timestamp
-FROM (
     SELECT
-        CONCAT('[', LISTAGG(read_input, ','), ']') AS batch_read
-    FROM (
-        SELECT 
-            deployer_address,
-            contract_address,
-            block_number,
-            function_sig,
-            function_input,
-            CONCAT(
-                '[\'',
-                contract_address,
-                '\',',
-                block_number,
-                ',\'',
-                function_sig,
-                '\',\'',
-                (CASE WHEN function_input IS NULL THEN '' ELSE function_input::STRING END),
-                '\']'
-                ) AS read_input,
-                row_num
-        FROM all_inputs
-        LEFT JOIN contract_deployments USING(contract_address) 
-            ) ready_reads_pools
-    WHERE row_num BETWEEN {{ item * 500 + 1 }} AND {{ (item + 1) * 500}}
-    ) batch_reads_pools
-JOIN {{ source(
-            'streamline_crosschain',
-            'node_mapping'
-        ) }} ON 1=1 
-    AND chain = 'arbitrum'
-) {% if not loop.last %}
-UNION ALL
-{% endif %}
-{% endfor %}
+        deployer_address,
+        contract_address,
+        block_number,
+        function_sig,
+        (ROW_NUMBER() over (PARTITION BY contract_address
+    ORDER BY
+        block_number)) - 1 AS function_input
+    FROM
+        contract_deployments
+        JOIN function_sigs
+        ON 1 = 1
+        JOIN function_inputs
+        ON 1 = 1
+    WHERE
+        function_name = 'coins'
 ),
-
-reads_adjusted AS (
-    
+inputs_base_coins AS (
+    SELECT
+        deployer_address,
+        contract_address,
+        block_number,
+        function_sig,
+        (ROW_NUMBER() over (PARTITION BY contract_address
+    ORDER BY
+        block_number)) - 1 AS function_input
+    FROM
+        contract_deployments
+        JOIN function_sigs
+        ON 1 = 1
+        JOIN function_inputs
+        ON 1 = 1
+    WHERE
+        function_name = 'base_coins'
+),
+inputs_underlying_coins AS (
+    SELECT
+        deployer_address,
+        contract_address,
+        block_number,
+        function_sig,
+        (ROW_NUMBER() over (PARTITION BY contract_address
+    ORDER BY
+        block_number)) - 1 AS function_input
+    FROM
+        contract_deployments
+        JOIN function_sigs
+        ON 1 = 1
+        JOIN function_inputs
+        ON 1 = 1
+    WHERE
+        function_name = 'underlying_coins'
+),
+inputs_pool_details AS (
+    SELECT
+        deployer_address,
+        contract_address,
+        block_number,
+        function_sig,
+        NULL AS function_input
+    FROM
+        contract_deployments
+        JOIN function_sigs
+        ON 1 = 1
+    WHERE
+        function_name IN (
+            'name',
+            'symbol',
+            'decimals'
+        )
+),
+all_inputs AS (
+    SELECT
+        deployer_address,
+        contract_address,
+        block_number,
+        function_sig,
+        function_input
+    FROM
+        inputs_coins
+    UNION ALL
+    SELECT
+        deployer_address,
+        contract_address,
+        block_number,
+        function_sig,
+        function_input
+    FROM
+        inputs_base_coins
+    UNION ALL
+    SELECT
+        deployer_address,
+        contract_address,
+        block_number,
+        function_sig,
+        function_input
+    FROM
+        inputs_underlying_coins
+    UNION ALL
+    SELECT
+        deployer_address,
+        contract_address,
+        block_number,
+        function_sig,
+        function_input
+    FROM
+        inputs_pool_details
+),
+pool_token_reads AS ({% for item in range(5) %}
+    (
 SELECT
-        VALUE :id :: STRING AS read_id,
-        VALUE :result :: STRING AS read_result,
-        SPLIT(
-            read_id,
-            '-'
-        ) AS read_id_object,
-        read_id_object [0] :: STRING AS contract_address,
-        read_id_object [1] :: STRING AS block_number,
-        read_id_object [2] :: STRING AS function_sig,
-        read_id_object [3] :: STRING AS function_input,
-        _inserted_timestamp
+    ethereum.streamline.udf_json_rpc_read_calls(node_url, headers, PARSE_JSON(batch_read)) AS read_output, SYSDATE() AS _inserted_timestamp
 FROM
-    pool_token_reads,
-    LATERAL FLATTEN(
-        input => read_output [0] :data
-    ) 
-),
-
-tokens AS (
-    
+    (
 SELECT
-    contract_address,
-    function_sig,
-    function_name,
-    function_input,
-    read_result,
-    regexp_substr_all(SUBSTR(read_result, 3, len(read_result)), '.{64}')[0]AS segmented_token_address,
-    _inserted_timestamp
-FROM reads_adjusted
-LEFT JOIN function_sigs USING(function_sig)
-WHERE function_name IN ('coins','base_coins','underlying_coins')
-    AND read_result IS NOT NULL
-    
-),
-
-pool_details AS (
-
+    CONCAT('[', LISTAGG(read_input, ','), ']') AS batch_read
+FROM
+    (
 SELECT
-    contract_address,
-    function_sig,
-    function_name,
-    function_input,
-    read_result,
-    regexp_substr_all(SUBSTR(read_result, 3, len(read_result)), '.{64}') AS segmented_output,
-    _inserted_timestamp
-FROM reads_adjusted
-LEFT JOIN function_sigs USING(function_sig)
-WHERE function_name IN ('name','symbol','decimals')
-    AND read_result IS NOT NULL
-
-),
-
-all_pools AS (
+    deployer_address, contract_address, block_number, function_sig, function_input, CONCAT('[\'', contract_address, '\',', block_number, ',\'', function_sig, '\',\'', (CASE
+    WHEN function_input IS NULL THEN ''
+    ELSE function_input :: stringend), '\']') AS read_input, row_num
+FROM
+    all_inputs
+    LEFT JOIN contract_deployments USING(contract_address)) ready_reads_pools
+WHERE
+    row_num BETWEEN {{ item * 500 + 1 }}
+    AND {{(item + 1) * 500 }}) batch_reads_pools
+    JOIN {{ source('streamline_crosschain', 'node_mapping') }}
+    ON 1 = 1
+    AND chain = 'arbitrum') {% if not loop.last %}
+    UNION ALL
+    {% endif %}
+{% endfor %}), reads_adjusted AS (
 SELECT
-    t.contract_address AS pool_address,
-    CONCAT('0x',SUBSTRING(t.segmented_token_address,25,40)) AS token_address,
-    function_input AS token_id,
-    function_name AS token_type,
-    MIN(CASE WHEN p.function_name = 'symbol' THEN TRY_HEX_DECODE_STRING(RTRIM(p.segmented_output [2] :: STRING, 0)) END) AS pool_symbol,
-    MIN(CASE WHEN p.function_name = 'name' THEN CONCAT(TRY_HEX_DECODE_STRING(p.segmented_output [2] :: STRING),
-        TRY_HEX_DECODE_STRING(segmented_output [3] :: STRING)) END) AS pool_name,
-    MIN(CASE 
-            WHEN p.read_result::STRING = '0x' THEN NULL
-            ELSE utils.udf_hex_to_int(LEFT(p.read_result::STRING,66))
-        END)::INTEGER  AS pool_decimals,
-    CONCAT(
-        t.contract_address,
-        '-',
-        CONCAT('0x',SUBSTRING(t.segmented_token_address,25,40)),
-        '-',
-        function_input,
-        '-',
-        function_name
-    ) AS pool_id,
-    MAX(t._inserted_timestamp) AS _inserted_timestamp
-FROM tokens t
-LEFT JOIN pool_details p USING(contract_address)
-WHERE token_address IS NOT NULL 
+    VALUE :id :: STRING AS read_id, VALUE :result :: STRING AS read_result, SPLIT(read_id, '-') AS read_id_object, read_id_object [0] :: STRING AS contract_address, read_id_object [1] :: STRING AS block_number, read_id_object [2] :: STRING AS function_sig, read_id_object [3] :: STRING AS function_input, _inserted_timestamp
+FROM
+    pool_token_reads, LATERAL FLATTEN(input => read_output [0] :data)), tokens AS (
+SELECT
+    contract_address, function_sig, function_name, function_input, read_result, regexp_substr_all(SUBSTR(read_result, 3, len(read_result)), '.{64}') [0] AS segmented_token_address, _inserted_timestamp
+FROM
+    reads_adjusted
+    LEFT JOIN function_sigs USING(function_sig)
+WHERE
+    function_name IN ('coins', 'base_coins', 'underlying_coins')
+    AND read_result IS NOT NULL), pool_details AS (
+SELECT
+    contract_address, function_sig, function_name, function_input, read_result, regexp_substr_all(SUBSTR(read_result, 3, len(read_result)), '.{64}') AS segmented_output, _inserted_timestamp
+FROM
+    reads_adjusted
+    LEFT JOIN function_sigs USING(function_sig)
+WHERE
+    function_name IN ('name', 'symbol', 'decimals')
+    AND read_result IS NOT NULL), all_pools AS (
+SELECT
+    t.contract_address AS pool_address, CONCAT('0x', SUBSTRING(t.segmented_token_address, 25, 40)) AS token_address, function_input AS token_id, function_name AS token_type, MIN(CASE
+    WHEN p.function_name = 'symbol' THEN TRY_HEX_DECODE_STRING(RTRIM(p.segmented_output [2] :: STRING, 0))END) AS pool_symbol, MIN(CASE
+    WHEN p.function_name = 'name' THEN CONCAT(TRY_HEX_DECODE_STRING(p.segmented_output [2] :: STRING), TRY_HEX_DECODE_STRING(segmented_output [3] :: STRING))END) AS pool_name, MIN(CASE
+    WHEN p.read_result :: STRING = '0x' THEN NULL
+    ELSE utils.udf_hex_to_int(LEFT(p.read_result :: STRING, 66))END) :: INTEGER AS pool_decimals, CONCAT(t.contract_address, '-', CONCAT('0x', SUBSTRING(t.segmented_token_address, 25, 40)), '-', function_input, '-', function_name) AS pool_id, MAX(t._inserted_timestamp) AS _inserted_timestamp
+FROM
+    tokens t
+    LEFT JOIN pool_details p USING(contract_address)
+WHERE
+    token_address IS NOT NULL
     AND token_address <> '0x0000000000000000000000000000000000000000'
-GROUP BY 1,2,3,4
-),
-
-FINAL AS (
+GROUP BY
+    1, 2, 3, 4), FINAL AS (
 SELECT
-    pool_address,
-    CASE
-        WHEN token_address = '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee' THEN '0x82af49447d8a07e3bd95bd0d56f35241523fbab1'
-        ELSE token_address
-    END AS token_address,
-    token_id,
-    token_type,
-    CASE 
-        WHEN token_address = '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee' THEN 'WETH'
-        WHEN pool_symbol IS NULL THEN c.token_symbol
-        ELSE pool_symbol
-    END AS pool_symbol,
-    pool_name,
-    CASE 
-        WHEN token_address = '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee' THEN '18'
-    	WHEN pool_decimals IS NULL THEN c.token_decimals
-        ELSE pool_decimals
-    END AS pool_decimals,
-    pool_id,
-    a._inserted_timestamp
-FROM all_pools a
-LEFT JOIN {{ ref('silver__contracts') }} c ON a.token_address = c.contract_address
-)
-
+    pool_address, CASE
+    WHEN token_address = '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee' THEN '0x82af49447d8a07e3bd95bd0d56f35241523fbab1'
+    ELSE token_addressEND AS token_address, token_id, token_type, CASE
+    WHEN token_address = '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee' THEN 'WETH'
+    WHEN pool_symbol IS NULL THEN C.token_symbol
+    ELSE pool_symbolEND AS pool_symbol, pool_name, CASE
+    WHEN token_address = '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee' THEN '18'
+    WHEN pool_decimals IS NULL THEN C.token_decimals
+    ELSE pool_decimalsEND AS pool_decimals, pool_id, A._inserted_timestamp
+FROM
+    all_pools A
+    LEFT JOIN {{ ref('silver__contracts') }} C
+    ON A.token_address = C.contract_address)
 SELECT
-    pool_address,
-    token_address,
-    token_id,
-    token_type,
-    pool_symbol,
-    pool_name,
-    pool_decimals,
-    pool_id,
-    _inserted_timestamp
-FROM FINAL
+    pool_address, token_address, token_id, token_type, pool_symbol, pool_name, pool_decimals, pool_id, _inserted_timestamp
+FROM
+    FINAL

--- a/models/silver/dex/curve/silver_dex__curve_pools.yml
+++ b/models/silver/dex/curve/silver_dex__curve_pools.yml
@@ -1,0 +1,29 @@
+version: 2
+models:
+  - name: silver_dex__curve_pools
+   
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - POOL_ID
+    columns:
+      - name: POOL_ADDRESS
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - varchar
+      - name: TOKEN_ADDRESS
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - varchar
+      - name: POOL_SYMBOL
+      - name: POOL_NAME
+      - name: POOL_DECIMALS
+      - name: _INSERTED_TIMESTAMP

--- a/models/silver/dex/curve/silver_dex__curve_swaps.sql
+++ b/models/silver/dex/curve/silver_dex__curve_swaps.sql
@@ -1,0 +1,226 @@
+{{ config(
+    materialized = 'incremental',
+    unique_key = "_log_id",
+    cluster_by = ['block_timestamp::DATE']
+) }}
+
+WITH pool_meta AS (
+
+    SELECT
+        DISTINCT pool_address,
+        CASE 
+            WHEN pool_name IS NULL AND pool_symbol IS NULL THEN CONCAT('Curve.fi Pool: ',SUBSTRING(pool_address, 1, 5),'...',SUBSTRING(pool_address, 39, 42))
+            WHEN pool_name IS NULL THEN CONCAT('Curve.fi Pool: ',replace(regexp_replace(agg_symbol, '[^[:alnum:],]', '', 1, 0), ',', '-'))
+        ELSE pool_name
+    END AS pool_name,
+    token_address,
+    pool_symbol AS symbol,
+    token_id::INTEGER AS token_id,
+    token_type::STRING AS token_type
+    FROM
+        {{ ref('silver_dex__curve_pools') }}
+    LEFT JOIN (
+        SELECT
+            pool_address,
+            array_agg(DISTINCT pool_symbol)::STRING AS agg_symbol
+        FROM {{ ref('silver_dex__curve_pools') }}
+        GROUP BY 1
+        ) USING(pool_address)
+),
+
+pools AS (
+
+SELECT 
+	DISTINCT pool_address,
+	pool_name
+FROM pool_meta
+QUALIFY (ROW_NUMBER() OVER (PARTITION BY pool_address ORDER BY pool_name ASC)) = 1
+),
+
+curve_base AS (
+    SELECT
+        block_number,
+        block_timestamp,
+        tx_hash,
+        origin_function_signature,
+        origin_from_address,
+        origin_to_address,
+        contract_address,
+        event_index,
+        CASE
+            WHEN topics [0] :: STRING = '0xd013ca23e77a65003c2c659c5442c00c805371b7fc1ebd4c206c41d1536bd90b' THEN 'TokenExchangeUnderlying'
+            ELSE 'TokenExchange'
+        END AS event_name,
+        contract_address AS pool_address,
+        pool_name,
+        regexp_substr_all(SUBSTR(DATA, 3, len(DATA)), '.{64}') AS segmented_data,
+        CONCAT('0x', SUBSTR(topics [1] :: STRING, 27, 40)) AS sender,
+        TRY_TO_NUMBER(utils.udf_hex_to_int(
+            segmented_data [0] :: STRING
+        )) AS sold_id,
+        TRY_TO_NUMBER(utils.udf_hex_to_int(
+            segmented_data [1] :: STRING
+        )) AS tokens_sold,
+        TRY_TO_NUMBER(utils.udf_hex_to_int(
+            segmented_data [2] :: STRING
+        )) AS bought_id,
+        TRY_TO_NUMBER(utils.udf_hex_to_int(
+            segmented_data [3] :: STRING
+        )) AS tokens_bought,
+        _log_id,
+        _inserted_timestamp
+    FROM
+        {{ ref('silver__logs2') }}
+        INNER JOIN pools
+        ON pools.pool_address = contract_address
+    WHERE
+        topics [0] :: STRING IN (
+            '0x8b3e96f2b889fa771c53c981b40daf005f63f637f1869f707052d15a3dd97140',
+            '0xb2e76ae99761dc136e598d4a629bb347eccb9532a5f8bbd72e18467c3c34cc98',
+            '0xd013ca23e77a65003c2c659c5442c00c805371b7fc1ebd4c206c41d1536bd90b'
+        )
+
+{% if is_incremental() %}
+AND _inserted_timestamp >= (
+    SELECT
+        MAX(_inserted_timestamp) :: DATE
+    FROM
+        {{ this }}
+)
+{% endif %}
+),
+
+token_exchange AS (
+
+SELECT
+	_log_id,
+    MAX(CASE WHEN sold_id = token_id THEN token_address END) AS token_in,
+    MAX(CASE WHEN bought_id = token_id THEN token_address END) AS token_out,
+    MAX(CASE WHEN sold_id = token_id THEN symbol END) AS symbol_in,
+    MAX(CASE WHEN bought_id = token_id THEN symbol END) AS symbol_out
+FROM curve_base t
+LEFT JOIN pool_meta p ON p.pool_address = t.pool_address AND (p.token_id = t.sold_id OR p.token_id = t.bought_id)
+WHERE token_type = 'coins'
+GROUP BY 1
+),
+
+token_transfers AS (
+    SELECT
+        tx_hash,
+        contract_address AS token_address,
+        TRY_TO_NUMBER(
+            utils.udf_hex_to_int(
+                DATA :: STRING
+            )
+        ) AS amount,
+        CONCAT('0x', SUBSTR(topics [1] :: STRING, 27, 40)) AS from_address,
+        CONCAT('0x', SUBSTR(topics [2] :: STRING, 27, 40)) AS to_address
+    FROM
+        {{ ref('silver__logs2') }}
+    WHERE
+        topics [0] :: STRING = '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef'
+        AND tx_hash IN (
+            SELECT
+                DISTINCT tx_hash
+            FROM
+                curve_base
+        )
+        AND CONCAT('0x', SUBSTR(topics [2] :: STRING, 27, 40)) <> '0x0000000000000000000000000000000000000000'
+
+{% if is_incremental() %}
+AND _inserted_timestamp >= (
+    SELECT
+        MAX(_inserted_timestamp) :: DATE
+    FROM
+        {{ this }}
+)
+{% endif %}
+),
+from_transfers AS (
+    SELECT
+        DISTINCT tx_hash,
+        token_address,
+        from_address,
+        amount
+    FROM
+        token_transfers
+),
+to_transfers AS (
+    SELECT
+        DISTINCT tx_hash,
+        token_address,
+        to_address,
+        amount
+    FROM
+        token_transfers
+),
+
+ready_pool_info AS (
+
+SELECT
+	s.block_number,
+    s.block_timestamp,
+    s.tx_hash,
+    s.origin_function_signature,
+    s.origin_from_address,
+    s.origin_from_address AS tx_to,
+    s.origin_to_address,
+    event_index,
+    event_name,
+    pool_address,
+    pool_address AS contract_address,
+    pool_name,
+    sender,
+    sold_id,
+    tokens_sold,
+    COALESCE(sold.token_address,e.token_in) AS token_in,
+    e.symbol_in AS symbol_in,
+    bought_id,
+    tokens_bought,
+    COALESCE(bought.token_address,e.token_out) AS token_out,
+    e.symbol_out AS symbol_out,
+    s._log_id,
+    _inserted_timestamp
+FROM
+    curve_base s
+    LEFT JOIN token_exchange e ON s._log_id = e._log_id
+    LEFT JOIN from_transfers sold
+    ON tokens_sold = sold.amount
+    AND s.tx_hash = sold.tx_hash
+    LEFT JOIN to_transfers bought
+    ON tokens_bought = bought.amount
+    AND s.tx_hash = bought.tx_hash
+WHERE
+	tokens_sold <> 0
+qualify(ROW_NUMBER() over(PARTITION BY s._log_id
+    ORDER BY
+        _inserted_timestamp DESC)) = 1  
+)
+
+SELECT
+    block_number,
+    block_timestamp,
+    tx_hash,
+    origin_function_signature,
+    origin_from_address,
+    tx_to,
+    origin_to_address,
+    event_index,
+    event_name,
+    pool_address,
+    contract_address,
+    pool_name,
+    sender,
+    sold_id,
+    tokens_sold,
+    token_in,
+    symbol_in,
+    bought_id,
+    tokens_bought,
+    token_out,
+    symbol_out,
+    _log_id,
+    _inserted_timestamp,
+    'curve' AS platform
+FROM
+    ready_pool_info

--- a/models/silver/dex/curve/silver_dex__curve_swaps.sql
+++ b/models/silver/dex/curve/silver_dex__curve_swaps.sql
@@ -70,7 +70,7 @@ curve_base AS (
         _log_id,
         _inserted_timestamp
     FROM
-        {{ ref('silver__logs2') }}
+        {{ ref('silver__logs') }}
         INNER JOIN pools
         ON pools.pool_address = contract_address
     WHERE
@@ -116,7 +116,7 @@ token_transfers AS (
         CONCAT('0x', SUBSTR(topics [1] :: STRING, 27, 40)) AS from_address,
         CONCAT('0x', SUBSTR(topics [2] :: STRING, 27, 40)) AS to_address
     FROM
-        {{ ref('silver__logs2') }}
+        {{ ref('silver__logs') }}
     WHERE
         topics [0] :: STRING = '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef'
         AND tx_hash IN (

--- a/models/silver/dex/curve/silver_dex__curve_swaps.yml
+++ b/models/silver/dex/curve/silver_dex__curve_swaps.yml
@@ -1,0 +1,54 @@
+version: 2
+models:
+  - name: silver_dex__curve_swaps
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - _log_id
+    columns:
+      - name: TOKENS_SOLD
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - decimal
+                - float
+                - number
+      - name: TOKENS_BOUGHT
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - decimal
+                - float
+                - number
+      - name: BLOCK_TIMESTAMP
+        tests:
+          - not_null
+          - dbt_expectations.expect_row_values_to_have_recent_data:
+              datepart: day
+              interval: 1
+      - name: EVENT_INDEX
+        tests:
+          - not_null
+      - name: POOL_ADDRESS
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: POOL_NAME
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - varchar
+      - name: SENDER
+        tests:
+          - not_null
+      - name: TX_TO
+        tests:
+          - not_null
+      - name: TOKEN_IN
+      - name: TOKEN_OUT
+      - name: TX_HASH
+        tests:
+          - not_null

--- a/models/silver/dex/dodo/silver_dex__dodo_v1_swaps.sql
+++ b/models/silver/dex/dodo/silver_dex__dodo_v1_swaps.sql
@@ -65,7 +65,7 @@ sell_base_token AS (
         l._log_id,
         l._inserted_timestamp
     FROM
-        {{ ref('silver__logs2') }}
+        {{ ref('silver__logs') }}
         l
         INNER JOIN pools p
         ON p.pool_address = l.contract_address
@@ -118,7 +118,7 @@ buy_base_token AS (
         l._log_id,
         l._inserted_timestamp
     FROM
-        {{ ref('silver__logs2') }}
+        {{ ref('silver__logs') }}
         l
         INNER JOIN pools p
         ON p.pool_address = l.contract_address

--- a/models/silver/dex/dodo/silver_dex__dodo_v1_swaps.sql
+++ b/models/silver/dex/dodo/silver_dex__dodo_v1_swaps.sql
@@ -1,0 +1,185 @@
+{{ config(
+    materialized = 'incremental',
+    unique_key = '_log_id',
+    cluster_by = ['block_timestamp::DATE']
+) }}
+
+WITH pools AS (
+
+    SELECT
+        '0xfe176a2b1e1f67250d2903b8d25f56c0dabcd6b2' AS pool_address,
+        'WETH' AS base_token_symbol,
+        'USDC' AS quote_token_symbol,
+        '0x82af49447d8a07e3bd95bd0d56f35241523fbab1' AS base_token,
+        '0xff970a61a04b1ca14834a43f5de4533ebddb5cc8' AS quote_token
+    UNION
+    SELECT
+        '0xe4b2dfc82977dd2dce7e8d37895a6a8f50cbb4fb', 
+        'USDT',
+        'USDC',
+        '0xfd086bc7cd5c481dcc9c85ebe478a1c0b69fcbb9',
+        '0xff970a61a04b1ca14834a43f5de4533ebddb5cc8'
+    UNION
+    SELECT
+        '0xb42a054d950dafd872808b3c839fbb7afb86e14c',
+        'WBTC',
+        'USDC',
+        '0x2f2a2543b76a4166549f7aab2e75bef0aefc5b0f',
+        '0xff970a61a04b1ca14834a43f5de4533ebddb5cc8'
+),  
+proxies AS (
+    SELECT
+        '0xd5a7e197bace1f3b26e2760321d6ce06ad07281a' AS proxy_address
+    UNION
+    SELECT
+        '0x8ab2d334ce64b50be9ab04184f7ccba2a6bb6391' AS proxy_address
+),
+sell_base_token AS (
+    SELECT
+        l.block_number,
+        l.block_timestamp,
+        l.tx_hash,
+        origin_function_signature,
+        origin_from_address,
+        origin_to_address,
+        l.event_index,
+        l.contract_address,
+        regexp_substr_all(SUBSTR(l.data, 3, len(l.data)), '.{64}') AS l_segmented_data,
+        CONCAT('0x', SUBSTR(l.topics [1] :: STRING, 27, 40)) AS seller_address,
+        TRY_TO_NUMBER(
+            utils.udf_hex_to_int(
+                l_segmented_data [0] :: STRING
+            )
+        ) AS payBase,
+        TRY_TO_NUMBER(
+            utils.udf_hex_to_int(
+                l_segmented_data [1] :: STRING
+            )
+        ) AS receiveQuote,
+        base_token,
+        quote_token,
+        quote_token AS tokenIn,
+        base_token AS tokenOut,
+        receiveQuote AS amountIn,
+        payBase AS amountOut,
+        l._log_id,
+        l._inserted_timestamp
+    FROM
+        {{ ref('silver__logs2') }}
+        l
+        INNER JOIN pools p
+        ON p.pool_address = l.contract_address
+    WHERE
+        topics [0] :: STRING = '0xd8648b6ac54162763c86fd54bf2005af8ecd2f9cb273a5775921fd7f91e17b2d' --sellBaseToken
+        AND seller_address NOT IN (
+            SELECT
+                proxy_address
+            FROM
+                proxies
+        )
+
+{% if is_incremental() %}
+AND _inserted_timestamp >= (
+    SELECT
+        MAX(_inserted_timestamp) :: DATE
+    FROM
+        {{ this }}
+)
+{% endif %}
+),
+buy_base_token AS (
+    SELECT
+        l.block_number,
+        l.block_timestamp,
+        l.tx_hash,
+        origin_function_signature,
+        origin_from_address,
+        origin_to_address,
+        l.event_index,
+        l.contract_address,
+        regexp_substr_all(SUBSTR(l.data, 3, len(l.data)), '.{64}') AS l_segmented_data,
+        CONCAT('0x', SUBSTR(l.topics [1] :: STRING, 27, 40)) AS buyer_address,
+        TRY_TO_NUMBER(
+            utils.udf_hex_to_int(
+                l_segmented_data [0] :: STRING
+            )
+        ) AS receiveBase,
+        TRY_TO_NUMBER(
+            utils.udf_hex_to_int(
+                l_segmented_data [1] :: STRING
+            )
+        ) AS payQuote,
+        base_token,
+        quote_token,
+        quote_token AS tokenIn,
+        base_token AS tokenOut,
+        payQuote AS amountIn,
+        receiveBase AS amountOut,
+        l._log_id,
+        l._inserted_timestamp
+    FROM
+        {{ ref('silver__logs2') }}
+        l
+        INNER JOIN pools p
+        ON p.pool_address = l.contract_address
+    WHERE
+        topics [0] :: STRING = '0xe93ad76094f247c0dafc1c61adc2187de1ac2738f7a3b49cb20b2263420251a3' --buyBaseToken
+        AND buyer_address NOT IN (
+            SELECT
+                proxy_address
+            FROM
+                proxies
+        )
+
+{% if is_incremental() %}
+AND _inserted_timestamp >= (
+    SELECT
+        MAX(_inserted_timestamp) :: DATE
+    FROM
+        {{ this }}
+)
+{% endif %}
+)
+SELECT
+    block_number,
+    block_timestamp,
+    tx_hash,
+    origin_function_signature,
+    origin_from_address,
+    origin_to_address,
+    event_index,
+    contract_address,
+    seller_address AS sender,
+    origin_from_address AS tx_to,
+    tokenIn AS token_in,
+    tokenOut AS token_out,
+    amountIn AS amount_in_unadj,
+    amountOut AS amount_out_unadj,
+    'SellBaseToken' AS event_name,
+    'dodo-v1' AS platform,
+    _log_id,
+    _inserted_timestamp
+FROM
+    sell_base_token
+UNION ALL
+SELECT
+    block_number,
+    block_timestamp,
+    tx_hash,
+    origin_function_signature,
+    origin_from_address,
+    origin_to_address,
+    event_index,
+    contract_address,
+    buyer_address AS sender,
+    origin_from_address AS tx_to,
+    tokenIn AS token_in,
+    tokenOut AS token_out,
+    amountIn AS amount_in_unadj,
+    amountOut AS amount_out_unadj,
+    'BuyBaseToken' AS event_name,
+    'dodo-v1' AS platform,
+    _log_id,
+    _inserted_timestamp
+FROM
+    buy_base_token

--- a/models/silver/dex/dodo/silver_dex__dodo_v1_swaps.yml
+++ b/models/silver/dex/dodo/silver_dex__dodo_v1_swaps.yml
@@ -1,0 +1,56 @@
+version: 2
+models:
+  - name: silver_dex__dodo_v1_swaps
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - _LOG_ID
+    columns:
+      - name: AMOUNT_IN_UNADJ
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - decimal
+                - float
+                - number
+      - name: AMOUNT_OUT_UNADJ
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - decimal
+                - float
+                - number
+      - name: TOKEN_IN
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: TOKEN_OUT
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: BLOCK_TIMESTAMP
+        tests:
+          - not_null
+          - dbt_expectations.expect_row_values_to_have_recent_data:
+              datepart: day
+              interval: 1
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - TIMESTAMP_LTZ
+                - TIMESTAMP_NTZ
+      - name: EVENT_INDEX
+        tests:
+          - not_null
+      - name: SENDER
+        tests:
+          - not_null
+      - name: TX_TO
+        tests:
+          - not_null
+      - name: TX_HASH
+        tests:
+          - not_null

--- a/models/silver/dex/dodo/silver_dex__dodo_v2_pools.sql
+++ b/models/silver/dex/dodo/silver_dex__dodo_v2_pools.sql
@@ -19,7 +19,7 @@ WITH pools AS (
         _log_id,
         _inserted_timestamp
     FROM
-        {{ ref ('silver__logs2') }}
+        {{ ref ('silver__logs') }}
     WHERE
         contract_address IN (
             '0xa6cf3d163358af376ec5e8b7cc5e102a05fde63d',

--- a/models/silver/dex/dodo/silver_dex__dodo_v2_pools.sql
+++ b/models/silver/dex/dodo/silver_dex__dodo_v2_pools.sql
@@ -1,0 +1,74 @@
+{{ config(
+    materialized = 'incremental',
+    unique_key = "pool_address"
+) }}
+
+WITH pools AS (
+
+    SELECT
+        block_number,
+        block_timestamp,
+        tx_hash,
+        event_index,
+        contract_address,
+        regexp_substr_all(SUBSTR(DATA, 3, len(DATA)), '.{64}') AS segmented_data,
+        CONCAT('0x', SUBSTR(segmented_data [0] :: STRING, 25, 40)) AS baseToken,
+        CONCAT('0x', SUBSTR(segmented_data [1] :: STRING, 25, 40)) AS quoteToken,
+        CONCAT('0x', SUBSTR(segmented_data [2] :: STRING, 25, 40)) AS creator,
+        CONCAT('0x', SUBSTR(segmented_data [3] :: STRING, 25, 40)) AS pool_address,
+        _log_id,
+        _inserted_timestamp
+    FROM
+        {{ ref ('silver__logs2') }}
+    WHERE
+        contract_address IN (
+            '0xa6cf3d163358af376ec5e8b7cc5e102a05fde63d',
+            '0xddb13e6dd168e1a68dc2285cb212078ae10394a9',
+            --dpp - factory,
+            '0x7b07164ecfaf0f0d85dfc062bc205a4674c75aa0',
+            '0x1506b54a1c0ea1b2f4a84866ec5776f7f6e7f0b1',
+            --dpp oracle
+            '0x9340e3296121507318874ce9c04afb4492af0284',
+            '0xc8fe2440744dcd733246a4db14093664defd5a53',
+            --dsp - factory
+            '0xda4c4411c55b0785e501332354a036c04833b72b' --dvm - factory
+        )
+        AND topics [0] :: STRING IN (
+            '0x8494fe594cd5087021d4b11758a2bbc7be28a430e94f2b268d668e5991ed3b8a',
+            --NewDPP
+            '0xbc1083a2c1c5ef31e13fb436953d22b47880cf7db279c2c5666b16083afd6b9d',
+            --NewDSP
+            '0xaf5c5f12a80fc937520df6fcaed66262a4cc775e0f3fceaf7a7cfe476d9a751d' --NewDVM
+        )
+
+{% if is_incremental() %}
+AND _inserted_timestamp >= (
+    SELECT
+        MAX(_inserted_timestamp) :: DATE
+    FROM
+        {{ this }}
+)
+AND pool_address NOT IN (
+    SELECT
+        DISTINCT pool_address
+    FROM
+        {{ this }}
+)
+{% endif %}
+)
+SELECT
+    block_number,
+    block_timestamp,
+    tx_hash,
+    event_index,
+    contract_address,
+    baseToken AS base_token,
+    quoteToken AS quote_token,
+    creator,
+    pool_address,
+    _log_id,
+    _inserted_timestamp
+FROM
+    pools qualify(ROW_NUMBER() over (PARTITION BY pool_address
+ORDER BY
+    _inserted_timestamp DESC)) = 1

--- a/models/silver/dex/dodo/silver_dex__dodo_v2_pools.yml
+++ b/models/silver/dex/dodo/silver_dex__dodo_v2_pools.yml
@@ -1,0 +1,17 @@
+version: 2
+models:
+  - name: silver_dex__dodo_v2_pools
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - POOL_ADDRESS
+    columns:
+      - name: POOL_ADDRESS
+        tests:
+          - not_null
+      - name: _INSERTED_TIMESTAMP
+        tests: 
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - TIMESTAMP_LTZ
+                - TIMESTAMP_NTZ

--- a/models/silver/dex/dodo/silver_dex__dodo_v2_swaps.sql
+++ b/models/silver/dex/dodo/silver_dex__dodo_v2_swaps.sql
@@ -74,7 +74,7 @@ swaps_base AS (
         l._log_id,
         l._inserted_timestamp
     FROM
-        {{ ref('silver__logs2') }}
+        {{ ref('silver__logs') }}
         l
     INNER JOIN pools p
     ON

--- a/models/silver/dex/dodo/silver_dex__dodo_v2_swaps.sql
+++ b/models/silver/dex/dodo/silver_dex__dodo_v2_swaps.sql
@@ -1,0 +1,120 @@
+{{ config(
+    materialized = 'incremental',
+    unique_key = '_log_id',
+    cluster_by = ['block_timestamp::DATE']
+) }}
+
+WITH pools AS (
+
+    SELECT
+        DISTINCT pool_address
+    FROM
+        {{ ref('silver_dex__dodo_v2_pools') }}
+),
+proxies AS (
+    SELECT
+        '0xd5a7e197bace1f3b26e2760321d6ce06ad07281a' AS proxy_address
+    UNION
+    SELECT
+        '0x8ab2d334ce64b50be9ab04184f7ccba2a6bb6391' AS proxy_address
+),
+swaps_base AS (
+    SELECT
+        l.block_number,
+        l.block_timestamp,
+        l.tx_hash,
+        origin_function_signature,
+        origin_from_address,
+        origin_to_address,
+        l.event_index,
+        l.contract_address,
+        regexp_substr_all(SUBSTR(l.data, 3, len(l.data)), '.{64}') AS l_segmented_data,
+        CONCAT(
+            '0x',
+            SUBSTR(
+                l_segmented_data [0] :: STRING,
+                25,
+                40
+            )
+        ) AS fromToken,
+        CONCAT(
+            '0x',
+            SUBSTR(
+                l_segmented_data [1] :: STRING,
+                25,
+                40
+            )
+        ) AS toToken,
+        TRY_TO_NUMBER(
+            utils.udf_hex_to_int(
+                l_segmented_data [2] :: STRING
+            )
+        ) AS fromAmount,
+        TRY_TO_NUMBER(
+            utils.udf_hex_to_int(
+                l_segmented_data [3] :: STRING
+            )
+        ) AS toAmount,
+        CONCAT(
+            '0x',
+            SUBSTR(
+                l_segmented_data [4] :: STRING,
+                25,
+                40
+            )
+        ) AS trader_address,
+        CONCAT(
+            '0x',
+            SUBSTR(
+                l_segmented_data [5] :: STRING,
+                25,
+                40
+            )
+        ) AS receiver_address,
+        l._log_id,
+        l._inserted_timestamp
+    FROM
+        {{ ref('silver__logs2') }}
+        l
+    INNER JOIN pools p
+    ON
+        l.contract_address = p.pool_address
+    WHERE
+        l.topics [0] :: STRING = '0xc2c0245e056d5fb095f04cd6373bc770802ebd1e6c918eb78fdef843cdb37b0f' --dodoswap
+        AND trader_address NOT IN (
+            SELECT
+                proxy_address
+            FROM
+                proxies
+        )
+
+{% if is_incremental() %}
+AND _inserted_timestamp >= (
+    SELECT
+        MAX(_inserted_timestamp) :: DATE
+    FROM
+        {{ this }}
+)
+{% endif %}
+)
+SELECT
+    block_number,
+    block_timestamp,
+    tx_hash,
+    origin_function_signature,
+    origin_from_address,
+    origin_to_address,
+    event_index,
+    contract_address,
+    fromToken AS token_in,
+    toToken AS token_out,
+    fromAmount AS amount_in_unadj,
+    toAmount AS amount_out_unadj,
+    trader_address AS sender,
+    receiver_address AS tx_to,
+    'DodoSwap' AS event_name,
+    'dodo-v2' AS platform,
+    _log_id,
+    _inserted_timestamp
+FROM
+    swaps_base

--- a/models/silver/dex/dodo/silver_dex__dodo_v2_swaps.yml
+++ b/models/silver/dex/dodo/silver_dex__dodo_v2_swaps.yml
@@ -1,0 +1,56 @@
+version: 2
+models:
+  - name: silver_dex__dodo_v2_swaps
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - _LOG_ID
+    columns:
+      - name: AMOUNT_IN_UNADJ
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - decimal
+                - float
+                - number
+      - name: AMOUNT_OUT_UNADJ
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - decimal
+                - float
+                - number
+      - name: TOKEN_IN
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: TOKEN_OUT
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: BLOCK_TIMESTAMP
+        tests:
+          - not_null
+          - dbt_expectations.expect_row_values_to_have_recent_data:
+              datepart: day
+              interval: 1
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - TIMESTAMP_LTZ
+                - TIMESTAMP_NTZ
+      - name: EVENT_INDEX
+        tests:
+          - not_null
+      - name: SENDER
+        tests:
+          - not_null
+      - name: TX_TO
+        tests:
+          - not_null
+      - name: TX_HASH
+        tests:
+          - not_null

--- a/models/silver/dex/fraxswap/silver_dex__fraxswap_pools.sql
+++ b/models/silver/dex/fraxswap/silver_dex__fraxswap_pools.sql
@@ -21,7 +21,7 @@ WITH pool_creation AS (
         _log_id,
         _inserted_timestamp
     FROM
-        {{ ref ('silver__logs2') }}
+        {{ ref ('silver__logs') }}
     WHERE
         contract_address IN (
             '0x5ca135cb8527d76e932f34b5145575f9d8cbe08e', --v1 factory

--- a/models/silver/dex/fraxswap/silver_dex__fraxswap_pools.sql
+++ b/models/silver/dex/fraxswap/silver_dex__fraxswap_pools.sql
@@ -1,0 +1,59 @@
+{{ config(
+    materialized = 'incremental',
+    unique_key = "pool_address"
+) }}
+
+WITH pool_creation AS (
+
+    SELECT
+        block_number,
+        block_timestamp,
+        tx_hash,
+        event_index,
+        contract_address AS factory_address,
+        regexp_substr_all(SUBSTR(DATA, 3, len(DATA)), '.{64}') AS segmented_data,
+        CONCAT('0x', SUBSTR(topics [1] :: STRING, 27, 40)) AS token0,
+        CONCAT('0x', SUBSTR(topics [2] :: STRING, 27, 40)) AS token1,
+        CONCAT('0x', SUBSTR(segmented_data [0] :: STRING, 25, 40)) AS pool_address,
+        utils.udf_hex_to_int(
+            segmented_data [1] :: STRING
+        ) :: INT AS pool_id,
+        _log_id,
+        _inserted_timestamp
+    FROM
+        {{ ref ('silver__logs2') }}
+    WHERE
+        contract_address IN (
+            '0x5ca135cb8527d76e932f34b5145575f9d8cbe08e', --v1 factory
+            '0x8374a74a728f06bea6b7259c68aa7bbb732bfead' --v2 factory
+        )
+        AND topics [0] :: STRING = '0x0d3648bd0f6ba80134a33ba9275ac585d9d315f0ad8355cddefde31afa28d0e9' --pairCreated
+
+{% if is_incremental() %}
+AND _inserted_timestamp >= (
+    SELECT
+        MAX(_inserted_timestamp) :: DATE
+    FROM
+        {{ this }}
+)
+AND pool_address NOT IN (
+    SELECT
+        DISTINCT pool_address
+    FROM
+        {{ this }}
+)
+{% endif %}
+)
+SELECT
+    block_number,
+    block_timestamp,
+    tx_hash,
+    event_index,
+    token0,
+    token1,
+    pool_address,
+    pool_id,
+    _log_id,
+    _inserted_timestamp
+FROM
+    pool_creation

--- a/models/silver/dex/fraxswap/silver_dex__fraxswap_pools.yml
+++ b/models/silver/dex/fraxswap/silver_dex__fraxswap_pools.yml
@@ -1,0 +1,23 @@
+version: 2
+models:
+  - name: silver_dex__fraxswap_pools
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - POOL_ADDRESS
+    columns:
+      - name: POOL_ADDRESS
+        tests:
+          - not_null
+      - name: TOKEN0
+        tests:
+          - not_null
+      - name: TOKEN1
+        tests:
+          - not_null
+      - name: _INSERTED_TIMESTAMP
+        tests: 
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - TIMESTAMP_LTZ
+                - TIMESTAMP_NTZ

--- a/models/silver/dex/fraxswap/silver_dex__fraxswap_swaps.sql
+++ b/models/silver/dex/fraxswap/silver_dex__fraxswap_swaps.sql
@@ -1,0 +1,115 @@
+{{ config(
+    materialized = 'incremental',
+    unique_key = '_log_id',
+    cluster_by = ['block_timestamp::DATE']
+) }}
+
+WITH pools AS (
+
+    SELECT
+        pool_address,
+        token0,
+        token1
+    FROM
+        {{ ref('silver_dex__fraxswap_pools') }}
+),
+swaps_base AS (
+    SELECT
+        l.block_number,
+        l.block_timestamp,
+        l.tx_hash,
+        origin_function_signature,
+        origin_from_address,
+        origin_to_address,
+        l.event_index,
+        l.contract_address,
+        regexp_substr_all(SUBSTR(l.data, 3, len(l.data)), '.{64}') AS l_segmented_data,
+        CONCAT('0x', SUBSTR(l.topics [1] :: STRING, 27, 40)) AS sender_address,
+        CONCAT('0x', SUBSTR(l.topics [2] :: STRING, 27, 40)) AS to_address,
+        TRY_TO_NUMBER(
+            utils.udf_hex_to_int(
+                l_segmented_data [0] :: STRING
+            )
+        ) AS amount0In,
+        TRY_TO_NUMBER(
+            utils.udf_hex_to_int(
+                l_segmented_data [1] :: STRING
+            )
+        ) AS amount1In,
+        TRY_TO_NUMBER(
+            utils.udf_hex_to_int(
+                l_segmented_data [2] :: STRING
+            )
+        ) AS amount0Out,
+        TRY_TO_NUMBER(
+            utils.udf_hex_to_int(
+                l_segmented_data [3] :: STRING
+            )
+        ) AS amount1Out,
+        token0,
+        token1,
+        l._log_id,
+        l._inserted_timestamp
+    FROM
+        {{ ref('silver__logs2') }}
+        l
+        INNER JOIN pools
+        ON l.contract_address = pool_address
+    WHERE
+        l.topics [0] :: STRING = '0xd78ad95fa46c994b6551d0da85fc275fe613ce37657fb8d5e3d130840159d822' --Swap
+
+{% if is_incremental() %}
+AND _inserted_timestamp >= (
+    SELECT
+        MAX(_inserted_timestamp) :: DATE
+    FROM
+        {{ this }}
+)
+{% endif %}
+)
+SELECT
+    block_number,
+    block_timestamp,
+    tx_hash,
+    origin_function_signature,
+    origin_from_address,
+    origin_to_address,
+    event_index,
+    contract_address,
+    sender_address AS sender,
+    to_address AS tx_to,
+    amount0In,
+    amount1In,
+    amount0Out,
+    amount1Out,
+    token0,
+    token1,
+    CASE
+        WHEN amount0In <> 0
+        AND amount1In <> 0
+        AND amount0Out <> 0 THEN amount1In
+        WHEN amount0In <> 0 THEN amount0In
+        WHEN amount1In <> 0 THEN amount1In
+    END AS amount_in_unadj,
+    CASE
+        WHEN amount0Out <> 0 THEN amount0Out
+        WHEN amount1Out <> 0 THEN amount1Out
+    END AS amount_out_unadj,
+    CASE
+        WHEN amount0In <> 0
+        AND amount1In <> 0
+        AND amount0Out <> 0 THEN token1
+        WHEN amount0In <> 0 THEN token0
+        WHEN amount1In <> 0 THEN token1
+    END AS token_in,
+    CASE
+        WHEN amount0Out <> 0 THEN token0
+        WHEN amount1Out <> 0 THEN token1
+    END AS token_out,
+    'Swap' AS event_name,
+    'fraxswap' AS platform,
+    _log_id,
+    _inserted_timestamp
+FROM
+    swaps_base
+WHERE token_in <> token_out

--- a/models/silver/dex/fraxswap/silver_dex__fraxswap_swaps.sql
+++ b/models/silver/dex/fraxswap/silver_dex__fraxswap_swaps.sql
@@ -51,7 +51,7 @@ swaps_base AS (
         l._log_id,
         l._inserted_timestamp
     FROM
-        {{ ref('silver__logs2') }}
+        {{ ref('silver__logs') }}
         l
         INNER JOIN pools
         ON l.contract_address = pool_address

--- a/models/silver/dex/fraxswap/silver_dex__fraxswap_swaps.yml
+++ b/models/silver/dex/fraxswap/silver_dex__fraxswap_swaps.yml
@@ -1,0 +1,81 @@
+version: 2
+models:
+  - name: silver_dex__fraxswap_swaps
+   
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - _LOG_ID
+    columns:
+      - name: BLOCK_NUMBER
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - FLOAT
+      - name: BLOCK_TIMESTAMP
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - TIMESTAMP_LTZ
+                - TIMESTAMP_NTZ
+      - name: TX_HASH
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: CONTRACT_ADDRESS
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: TOKEN_IN
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: TOKEN_OUT
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: SENDER
+        tests:
+          - not_null:
+              where: BLOCK_TIMESTAMP > '2021-08-01'
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: TX_TO
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: PLATFORM
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - STRING
+                - VARCHAR
+      - name: EVENT_INDEX
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - FLOAT
+      - name: _LOG_ID
+        tests:
+          - not_null
+      - name: ORIGIN_FUNCTION_SIGNATURE
+        tests:
+          - not_null
+      - name: ORIGIN_FROM_ADDRESS
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: ORIGIN_TO_ADDRESS
+        tests:
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+

--- a/models/silver/dex/gmx/silver_dex__gmx_swaps.sql
+++ b/models/silver/dex/gmx/silver_dex__gmx_swaps.sql
@@ -53,7 +53,7 @@ WITH swaps_base AS (
         l._log_id,
         l._inserted_timestamp
     FROM
-        {{ ref('silver__logs2') }}
+        {{ ref('silver__logs') }}
         l
     WHERE
         contract_address IN (

--- a/models/silver/dex/gmx/silver_dex__gmx_swaps.sql
+++ b/models/silver/dex/gmx/silver_dex__gmx_swaps.sql
@@ -1,0 +1,93 @@
+{{ config(
+    materialized = 'incremental',
+    unique_key = '_log_id',
+    cluster_by = ['block_timestamp::DATE']
+) }}
+
+WITH swaps_base AS (
+
+    SELECT
+        l.block_number,
+        l.block_timestamp,
+        l.tx_hash,
+        origin_function_signature,
+        origin_from_address,
+        origin_to_address,
+        l.event_index,
+        l.contract_address,
+        regexp_substr_all(SUBSTR(l.data, 3, len(l.data)), '.{64}') AS l_segmented_data,
+        CONCAT(
+            '0x',
+            SUBSTR(
+                l_segmented_data [0] :: STRING,
+                25,
+                40
+            )
+        ) AS account_address,
+        CONCAT(
+            '0x',
+            SUBSTR(
+                l_segmented_data [1] :: STRING,
+                25,
+                40
+            )
+        ) AS tokenIn,
+        CONCAT(
+            '0x',
+            SUBSTR(
+                l_segmented_data [2] :: STRING,
+                25,
+                40
+            )
+        ) AS tokenOut,
+        TRY_TO_NUMBER(
+            utils.udf_hex_to_int(
+                l_segmented_data [3] :: STRING
+            )
+        ) AS amountIn,
+        TRY_TO_NUMBER(
+            utils.udf_hex_to_int(
+                l_segmented_data [4] :: STRING
+            )
+        ) AS amountOut,
+        l._log_id,
+        l._inserted_timestamp
+    FROM
+        {{ ref('silver__logs2') }}
+        l
+    WHERE
+        contract_address IN (
+            '0xabbc5f99639c9b6bcb58544ddf04efa6802f4064'
+        )
+        AND topics [0] :: STRING = '0xcd3829a3813dc3cdd188fd3d01dcf3268c16be2fdd2dd21d0665418816e46062' --Swap
+
+{% if is_incremental() %}
+AND _inserted_timestamp >= (
+    SELECT
+        MAX(_inserted_timestamp) :: DATE
+    FROM
+        {{ this }}
+)
+{% endif %}
+)
+SELECT
+    block_number,
+    block_timestamp,
+    tx_hash,
+    origin_function_signature,
+    origin_from_address,
+    origin_to_address,
+    event_index,
+    contract_address,
+    origin_from_address AS sender,
+    account_address AS tx_to,
+    tokenIn AS token_in,
+    tokenOut AS token_out,
+    amountIn AS amount_in_unadj,
+    amountOut AS amount_out_unadj,
+    'Swap' AS event_name,
+    'gmx' AS platform,
+    _log_id,
+    _inserted_timestamp
+FROM
+    swaps_base

--- a/models/silver/dex/gmx/silver_dex__gmx_swaps.yml
+++ b/models/silver/dex/gmx/silver_dex__gmx_swaps.yml
@@ -1,0 +1,81 @@
+version: 2
+models:
+  - name: silver_dex__gmx_swaps
+   
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - _LOG_ID
+    columns:
+      - name: BLOCK_NUMBER
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - FLOAT
+      - name: BLOCK_TIMESTAMP
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - TIMESTAMP_LTZ
+                - TIMESTAMP_NTZ
+      - name: TX_HASH
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: CONTRACT_ADDRESS
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: TOKEN_IN
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: TOKEN_OUT
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: SENDER
+        tests:
+          - not_null:
+              where: BLOCK_TIMESTAMP > '2021-08-01'
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: TX_TO
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: PLATFORM
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - STRING
+                - VARCHAR
+      - name: EVENT_INDEX
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - FLOAT
+      - name: _LOG_ID
+        tests:
+          - not_null
+      - name: ORIGIN_FUNCTION_SIGNATURE
+        tests:
+          - not_null
+      - name: ORIGIN_FROM_ADDRESS
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: ORIGIN_TO_ADDRESS
+        tests:
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+

--- a/models/silver/dex/kyberswap/silver_dex__kyberswap_v1_dynamic_pools.sql
+++ b/models/silver/dex/kyberswap/silver_dex__kyberswap_v1_dynamic_pools.sql
@@ -1,0 +1,63 @@
+{{ config(
+    materialized = 'incremental',
+    unique_key = "pool_address"
+) }}
+
+WITH pool_creation AS (
+
+    SELECT
+        block_number,
+        block_timestamp,
+        tx_hash,
+        event_index,
+        contract_address,
+        regexp_substr_all(SUBSTR(DATA, 3, len(DATA)), '.{64}') AS segmented_data,
+        CONCAT('0x', SUBSTR(topics [1] :: STRING, 27, 40)) AS token0,
+        CONCAT('0x', SUBSTR(topics [2] :: STRING, 27, 40)) AS token1,
+        CONCAT('0x', SUBSTR(segmented_data [0] :: STRING, 25, 40)) AS pool_address,
+        TRY_TO_NUMBER(
+            utils.udf_hex_to_int(
+                segmented_data [1] :: STRING
+            )
+        ) AS ampBps,
+        TRY_TO_NUMBER(
+            utils.udf_hex_to_int(
+                segmented_data [2] :: STRING
+            )
+        ) AS totalPool,
+        _log_id,
+        _inserted_timestamp
+    FROM
+        {{ ref ('silver__logs2') }}
+    WHERE
+        contract_address = LOWER('0xD9bfE9979e9CA4b2fe84bA5d4Cf963bBcB376974') --dynamic fee factory
+        AND topics [0] :: STRING = '0xfc574402c445e75f2b79b67884ff9c662244dce454c5ae68935fcd0bebb7c8ff' --created pool
+{% if is_incremental() %}
+AND _inserted_timestamp >= (
+    SELECT
+        MAX(_inserted_timestamp) :: DATE
+    FROM
+        {{ this }}
+)
+AND pool_address NOT IN (
+    SELECT
+        DISTINCT pool_address
+    FROM
+        {{ this }}
+)
+{% endif %}
+)
+SELECT
+    block_number,
+    block_timestamp,
+    tx_hash,
+    event_index,
+    token0,
+    token1,
+    pool_address,
+    ampBps AS amp_bps,
+    totalPool AS total_pool,
+    _log_id,
+    _inserted_timestamp
+FROM
+    pool_creation

--- a/models/silver/dex/kyberswap/silver_dex__kyberswap_v1_dynamic_pools.sql
+++ b/models/silver/dex/kyberswap/silver_dex__kyberswap_v1_dynamic_pools.sql
@@ -28,7 +28,7 @@ WITH pool_creation AS (
         _log_id,
         _inserted_timestamp
     FROM
-        {{ ref ('silver__logs2') }}
+        {{ ref ('silver__logs') }}
     WHERE
         contract_address = LOWER('0xD9bfE9979e9CA4b2fe84bA5d4Cf963bBcB376974') --dynamic fee factory
         AND topics [0] :: STRING = '0xfc574402c445e75f2b79b67884ff9c662244dce454c5ae68935fcd0bebb7c8ff' --created pool

--- a/models/silver/dex/kyberswap/silver_dex__kyberswap_v1_dynamic_pools.yml
+++ b/models/silver/dex/kyberswap/silver_dex__kyberswap_v1_dynamic_pools.yml
@@ -1,0 +1,24 @@
+version: 2
+models:
+  - name: silver_dex__kyberswap_v1_dynamic_pools
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - POOL_ADDRESS
+    columns:
+      - name: POOL_ADDRESS
+        tests:
+          - not_null
+      - name: TOKEN0
+        tests:
+          - not_null
+      - name: TOKEN1
+        tests:
+          - not_null
+      - name: _INSERTED_TIMESTAMP
+        tests: 
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - TIMESTAMP_LTZ
+                - TIMESTAMP_NTZ

--- a/models/silver/dex/kyberswap/silver_dex__kyberswap_v1_dynamic_swaps.sql
+++ b/models/silver/dex/kyberswap/silver_dex__kyberswap_v1_dynamic_swaps.sql
@@ -56,7 +56,7 @@ swaps_base AS (
         l._log_id,
         l._inserted_timestamp
     FROM
-        {{ ref('silver__logs2') }}
+        {{ ref('silver__logs') }}
         l
         INNER JOIN pools p
         ON p.pool_address = l.contract_address

--- a/models/silver/dex/kyberswap/silver_dex__kyberswap_v1_dynamic_swaps.sql
+++ b/models/silver/dex/kyberswap/silver_dex__kyberswap_v1_dynamic_swaps.sql
@@ -1,0 +1,122 @@
+{{ config(
+    materialized = 'incremental',
+    unique_key = '_log_id',
+    cluster_by = ['block_timestamp::DATE']
+) }}
+
+WITH pools AS (
+
+    SELECT
+        pool_address,
+        token0,
+        token1
+    FROM
+        {{ ref('silver_dex__kyberswap_v1_dynamic_pools') }}
+),
+swaps_base AS (
+    SELECT
+        l.block_number,
+        l.block_timestamp,
+        l.tx_hash,
+        origin_function_signature,
+        origin_from_address,
+        origin_to_address,
+        l.event_index,
+        l.contract_address,
+        regexp_substr_all(SUBSTR(l.data, 3, len(l.data)), '.{64}') AS l_segmented_data,
+        CONCAT('0x', SUBSTR(l.topics [1] :: STRING, 27, 40)) AS sender_address,
+        CONCAT('0x', SUBSTR(l.topics [2] :: STRING, 27, 40)) AS to_address,
+        TRY_TO_NUMBER(
+            utils.udf_hex_to_int(
+                l_segmented_data [0] :: STRING
+            )
+        ) AS amount0In,
+        TRY_TO_NUMBER(
+            utils.udf_hex_to_int(
+                l_segmented_data [1] :: STRING
+            )
+        ) AS amount1In,
+        TRY_TO_NUMBER(
+            utils.udf_hex_to_int(
+                l_segmented_data [2] :: STRING
+            )
+        ) AS amount0Out,
+        TRY_TO_NUMBER(
+            utils.udf_hex_to_int(
+                l_segmented_data [3] :: STRING
+            )
+        ) AS amount1Out,
+        TRY_TO_NUMBER(
+            utils.udf_hex_to_int(
+                l_segmented_data [4] :: STRING
+            )
+        ) AS feeInPrecision,
+        token0,
+        token1,
+        l._log_id,
+        l._inserted_timestamp
+    FROM
+        {{ ref('silver__logs2') }}
+        l
+        INNER JOIN pools p
+        ON p.pool_address = l.contract_address
+    WHERE
+        l.topics [0] :: STRING = '0x606ecd02b3e3b4778f8e97b2e03351de14224efaa5fa64e62200afc9395c2499' --Dynamic Swap
+
+{% if is_incremental() %}
+AND _inserted_timestamp >= (
+    SELECT
+        MAX(_inserted_timestamp) :: DATE
+    FROM
+        {{ this }}
+)
+{% endif %}
+)
+SELECT
+    block_number,
+    block_timestamp,
+    tx_hash,
+    contract_address,
+    origin_function_signature,
+    origin_from_address,
+    origin_to_address,
+    event_index,
+    sender_address AS sender,
+    to_address AS tx_to,
+    amount0In,
+    amount1In,
+    amount0Out,
+    amount1Out,
+    feeInPrecision AS fee_in_precision,
+    token0,
+    token1,
+    CASE
+        WHEN amount0In <> 0
+        AND amount1In <> 0
+        AND amount0Out <> 0 THEN amount1In
+        WHEN amount0In <> 0 THEN amount0In
+        WHEN amount1In <> 0 THEN amount1In
+    END AS amount_in_unadj,
+    CASE
+        WHEN amount0Out <> 0 THEN amount0Out
+        WHEN amount1Out <> 0 THEN amount1Out
+    END AS amount_out_unadj,
+    CASE
+        WHEN amount0In <> 0
+        AND amount1In <> 0
+        AND amount0Out <> 0 THEN token1
+        WHEN amount0In <> 0 THEN token0
+        WHEN amount1In <> 0 THEN token1
+    END AS token_in,
+    CASE
+        WHEN amount0Out <> 0 THEN token0
+        WHEN amount1Out <> 0 THEN token1
+    END AS token_out,
+    'Dynamic Swap' AS event_name,
+    'kyberswap-v1' AS platform,
+    _log_id,
+    _inserted_timestamp
+FROM
+    swaps_base
+WHERE
+    token_in <> token_out

--- a/models/silver/dex/kyberswap/silver_dex__kyberswap_v1_dynamic_swaps.yml
+++ b/models/silver/dex/kyberswap/silver_dex__kyberswap_v1_dynamic_swaps.yml
@@ -1,0 +1,81 @@
+version: 2
+models:
+  - name: silver_dex__kyberswap_v1_dynamic_swaps
+   
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - _LOG_ID
+    columns:
+      - name: BLOCK_NUMBER
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - FLOAT
+      - name: BLOCK_TIMESTAMP
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - TIMESTAMP_LTZ
+                - TIMESTAMP_NTZ
+      - name: TX_HASH
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: CONTRACT_ADDRESS
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: TOKEN_IN
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: TOKEN_OUT
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: SENDER
+        tests:
+          - not_null:
+              where: BLOCK_TIMESTAMP > '2021-08-01'
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: TX_TO
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: PLATFORM
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - STRING
+                - VARCHAR
+      - name: EVENT_INDEX
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - FLOAT
+      - name: _LOG_ID
+        tests:
+          - not_null
+      - name: ORIGIN_FUNCTION_SIGNATURE
+        tests:
+          - not_null
+      - name: ORIGIN_FROM_ADDRESS
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: ORIGIN_TO_ADDRESS
+        tests:
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+

--- a/models/silver/dex/kyberswap/silver_dex__kyberswap_v1_static_pools.sql
+++ b/models/silver/dex/kyberswap/silver_dex__kyberswap_v1_static_pools.sql
@@ -1,0 +1,70 @@
+{{ config(
+    materialized = 'incremental',
+    unique_key = "pool_address"
+) }}
+
+WITH pool_creation AS (
+
+    SELECT
+        block_number,
+        block_timestamp,
+        tx_hash,
+        event_index,
+        contract_address,
+        regexp_substr_all(SUBSTR(DATA, 3, len(DATA)), '.{64}') AS segmented_data,
+        CONCAT('0x', SUBSTR(topics [1] :: STRING, 27, 40)) AS token0,
+        CONCAT('0x', SUBSTR(topics [2] :: STRING, 27, 40)) AS token1,
+        CONCAT('0x', SUBSTR(segmented_data [0] :: STRING, 25, 40)) AS pool_address,
+        TRY_TO_NUMBER(
+            utils.udf_hex_to_int(
+                segmented_data [1] :: STRING
+            )
+        ) AS ampBps,
+        TRY_TO_NUMBER(
+            utils.udf_hex_to_int(
+                segmented_data [2] :: STRING
+            )
+        ) AS feeUnits,
+        TRY_TO_NUMBER(
+            utils.udf_hex_to_int(
+                segmented_data [3] :: STRING
+            )
+        ) AS totalPool,
+        _log_id,
+        _inserted_timestamp
+    FROM
+        {{ ref ('silver__logs2') }}
+    WHERE
+        contract_address = LOWER('0x1c758aF0688502e49140230F6b0EBd376d429be5') --static pool factory
+        AND topics [0] :: STRING = '0xb6bce363b712c921bead4bcc977289440eb6172eb89e258e3a25bd49ca806de6' --create pool
+
+{% if is_incremental() %}
+AND _inserted_timestamp >= (
+    SELECT
+        MAX(_inserted_timestamp) :: DATE
+    FROM
+        {{ this }}
+)
+AND pool_address NOT IN (
+    SELECT
+        DISTINCT pool_address
+    FROM
+        {{ this }}
+)
+{% endif %}
+)
+SELECT
+    block_number,
+    block_timestamp,
+    tx_hash,
+    event_index,
+    token0,
+    token1,
+    pool_address,
+    ampBps AS amp_bps,
+    feeUnits AS fee_units,
+    totalPool AS total_pool,
+    _log_id,
+    _inserted_timestamp
+FROM
+    pool_creation

--- a/models/silver/dex/kyberswap/silver_dex__kyberswap_v1_static_pools.sql
+++ b/models/silver/dex/kyberswap/silver_dex__kyberswap_v1_static_pools.sql
@@ -33,7 +33,7 @@ WITH pool_creation AS (
         _log_id,
         _inserted_timestamp
     FROM
-        {{ ref ('silver__logs2') }}
+        {{ ref ('silver__logs') }}
     WHERE
         contract_address = LOWER('0x1c758aF0688502e49140230F6b0EBd376d429be5') --static pool factory
         AND topics [0] :: STRING = '0xb6bce363b712c921bead4bcc977289440eb6172eb89e258e3a25bd49ca806de6' --create pool

--- a/models/silver/dex/kyberswap/silver_dex__kyberswap_v1_static_pools.yml
+++ b/models/silver/dex/kyberswap/silver_dex__kyberswap_v1_static_pools.yml
@@ -1,0 +1,23 @@
+version: 2
+models:
+  - name: silver_dex__kyberswap_v1_static_pools
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - POOL_ADDRESS
+    columns:
+      - name: POOL_ADDRESS
+        tests:
+          - not_null
+      - name: TOKEN0
+        tests:
+          - not_null
+      - name: TOKEN1
+        tests:
+          - not_null
+      - name: _INSERTED_TIMESTAMP
+        tests: 
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - TIMESTAMP_LTZ
+                - TIMESTAMP_NTZ

--- a/models/silver/dex/kyberswap/silver_dex__kyberswap_v1_static_swaps.sql
+++ b/models/silver/dex/kyberswap/silver_dex__kyberswap_v1_static_swaps.sql
@@ -56,7 +56,7 @@ swaps_base AS (
         l._log_id,
         l._inserted_timestamp
     FROM
-        {{ ref('silver__logs2') }}
+        {{ ref('silver__logs') }}
         l
         INNER JOIN pools p
         ON p.pool_address = l.contract_address

--- a/models/silver/dex/kyberswap/silver_dex__kyberswap_v1_static_swaps.sql
+++ b/models/silver/dex/kyberswap/silver_dex__kyberswap_v1_static_swaps.sql
@@ -1,0 +1,122 @@
+{{ config(
+    materialized = 'incremental',
+    unique_key = '_log_id',
+    cluster_by = ['block_timestamp::DATE']
+) }}
+
+WITH pools AS (
+
+    SELECT
+        pool_address,
+        token0,
+        token1
+    FROM
+        {{ ref('silver_dex__kyberswap_v1_static_pools') }}
+),
+swaps_base AS (
+    SELECT
+        l.block_number,
+        l.block_timestamp,
+        l.tx_hash,
+        origin_function_signature,
+        origin_from_address,
+        origin_to_address,
+        l.event_index,
+        l.contract_address,
+        regexp_substr_all(SUBSTR(l.data, 3, len(l.data)), '.{64}') AS l_segmented_data,
+        CONCAT('0x', SUBSTR(l.topics [1] :: STRING, 27, 40)) AS sender_address,
+        CONCAT('0x', SUBSTR(l.topics [2] :: STRING, 27, 40)) AS to_address,
+        TRY_TO_NUMBER(
+            utils.udf_hex_to_int(
+                l_segmented_data [0] :: STRING
+            )
+        ) AS amount0In,
+        TRY_TO_NUMBER(
+            utils.udf_hex_to_int(
+                l_segmented_data [1] :: STRING
+            )
+        ) AS amount1In,
+        TRY_TO_NUMBER(
+            utils.udf_hex_to_int(
+                l_segmented_data [2] :: STRING
+            )
+        ) AS amount0Out,
+        TRY_TO_NUMBER(
+            utils.udf_hex_to_int(
+                l_segmented_data [3] :: STRING
+            )
+        ) AS amount1Out,
+        TRY_TO_NUMBER(
+            utils.udf_hex_to_int(
+                l_segmented_data [4] :: STRING
+            )
+        ) AS feeInPrecision,
+        token0,
+        token1,
+        l._log_id,
+        l._inserted_timestamp
+    FROM
+        {{ ref('silver__logs2') }}
+        l
+        INNER JOIN pools p
+        ON p.pool_address = l.contract_address
+    WHERE
+        l.topics [0] :: STRING = '0x606ecd02b3e3b4778f8e97b2e03351de14224efaa5fa64e62200afc9395c2499' -- static swap
+
+{% if is_incremental() %}
+AND _inserted_timestamp >= (
+    SELECT
+        MAX(_inserted_timestamp) :: DATE
+    FROM
+        {{ this }}
+)
+{% endif %}
+)
+SELECT
+    block_number,
+    block_timestamp,
+    tx_hash,
+    contract_address,
+    origin_function_signature,
+    origin_from_address,
+    origin_to_address,
+    event_index,
+    sender_address AS sender,
+    to_address AS tx_to,
+    amount0In,
+    amount1In,
+    amount0Out,
+    amount1Out,
+    feeInPrecision AS fee_in_precision,
+    token0,
+    token1,
+    CASE
+        WHEN amount0In <> 0
+        AND amount1In <> 0
+        AND amount0Out <> 0 THEN amount1In
+        WHEN amount0In <> 0 THEN amount0In
+        WHEN amount1In <> 0 THEN amount1In
+    END AS amount_in_unadj,
+    CASE
+        WHEN amount0Out <> 0 THEN amount0Out
+        WHEN amount1Out <> 0 THEN amount1Out
+    END AS amount_out_unadj,
+    CASE
+        WHEN amount0In <> 0
+        AND amount1In <> 0
+        AND amount0Out <> 0 THEN token1
+        WHEN amount0In <> 0 THEN token0
+        WHEN amount1In <> 0 THEN token1
+    END AS token_in,
+    CASE
+        WHEN amount0Out <> 0 THEN token0
+        WHEN amount1Out <> 0 THEN token1
+    END AS token_out,
+    'Static Swap' AS event_name,
+    'kyberswap-v1' AS platform,
+    _log_id,
+    _inserted_timestamp
+FROM
+    swaps_base
+WHERE
+    token_in <> token_out

--- a/models/silver/dex/kyberswap/silver_dex__kyberswap_v1_static_swaps.yml
+++ b/models/silver/dex/kyberswap/silver_dex__kyberswap_v1_static_swaps.yml
@@ -1,0 +1,81 @@
+version: 2
+models:
+  - name: silver_dex__kyberswap_v1_static_swaps
+   
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - _LOG_ID
+    columns:
+      - name: BLOCK_NUMBER
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - FLOAT
+      - name: BLOCK_TIMESTAMP
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - TIMESTAMP_LTZ
+                - TIMESTAMP_NTZ
+      - name: TX_HASH
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: CONTRACT_ADDRESS
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: TOKEN_IN
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: TOKEN_OUT
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: SENDER
+        tests:
+          - not_null:
+              where: BLOCK_TIMESTAMP > '2021-08-01'
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: TX_TO
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: PLATFORM
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - STRING
+                - VARCHAR
+      - name: EVENT_INDEX
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - FLOAT
+      - name: _LOG_ID
+        tests:
+          - not_null
+      - name: ORIGIN_FUNCTION_SIGNATURE
+        tests:
+          - not_null
+      - name: ORIGIN_FROM_ADDRESS
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: ORIGIN_TO_ADDRESS
+        tests:
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+

--- a/models/silver/dex/kyberswap/silver_dex__kyberswap_v2_elastic_pools.sql
+++ b/models/silver/dex/kyberswap/silver_dex__kyberswap_v2_elastic_pools.sql
@@ -24,7 +24,7 @@ WITH pool_creation AS (
         _log_id,
         _inserted_timestamp
     FROM
-        {{ ref ('silver__logs2') }}
+        {{ ref ('silver__logs') }}
     WHERE
         contract_address = '0x5f1dddbf348ac2fbe22a163e30f99f9ece3dd50a' --Elastic Pool Deployer
         AND topics [0] :: STRING = '0x783cca1c0412dd0d695e784568c96da2e9c22ff989357a2e8b1d9b2b4e6b7118' --Create pool

--- a/models/silver/dex/kyberswap/silver_dex__kyberswap_v2_elastic_pools.sql
+++ b/models/silver/dex/kyberswap/silver_dex__kyberswap_v2_elastic_pools.sql
@@ -1,0 +1,60 @@
+{{ config(
+    materialized = 'incremental',
+    unique_key = "pool_address"
+) }}
+
+WITH pool_creation AS (
+
+    SELECT
+        block_number,
+        block_timestamp,
+        tx_hash,
+        event_index,
+        contract_address,
+        regexp_substr_all(SUBSTR(DATA, 3, len(DATA)), '.{64}') AS segmented_data,
+        CONCAT('0x', SUBSTR(topics [1] :: STRING, 27, 40)) AS token0,
+        CONCAT('0x', SUBSTR(topics [2] :: STRING, 27, 40)) AS token1,
+        TRY_TO_NUMBER(utils.udf_hex_to_int(topics [3] :: STRING)) AS swapFeeUnits,
+        TRY_TO_NUMBER(
+            utils.udf_hex_to_int(
+                segmented_data [0] :: STRING
+            )
+        ) AS tickDistance,
+        CONCAT('0x', SUBSTR(segmented_data [1] :: STRING, 25, 40)) AS pool_address,
+        _log_id,
+        _inserted_timestamp
+    FROM
+        {{ ref ('silver__logs2') }}
+    WHERE
+        contract_address = '0x5f1dddbf348ac2fbe22a163e30f99f9ece3dd50a' --Elastic Pool Deployer
+        AND topics [0] :: STRING = '0x783cca1c0412dd0d695e784568c96da2e9c22ff989357a2e8b1d9b2b4e6b7118' --Create pool
+
+{% if is_incremental() %}
+AND _inserted_timestamp >= (
+    SELECT
+        MAX(_inserted_timestamp) :: DATE
+    FROM
+        {{ this }}
+)
+AND pool_address NOT IN (
+    SELECT
+        DISTINCT pool_address
+    FROM
+        {{ this }}
+)
+{% endif %}
+)
+SELECT
+    block_number,
+    block_timestamp,
+    tx_hash,
+    event_index,
+    token0,
+    token1,
+    swapFeeUnits AS swap_fee_units,
+    tickDistance AS tick_distance,
+    pool_address,
+    _log_id,
+    _inserted_timestamp
+FROM
+    pool_creation

--- a/models/silver/dex/kyberswap/silver_dex__kyberswap_v2_elastic_pools.sql
+++ b/models/silver/dex/kyberswap/silver_dex__kyberswap_v2_elastic_pools.sql
@@ -26,7 +26,10 @@ WITH pool_creation AS (
     FROM
         {{ ref ('silver__logs') }}
     WHERE
-        contract_address = '0x5f1dddbf348ac2fbe22a163e30f99f9ece3dd50a' --Elastic Pool Deployer
+        contract_address IN (
+            '0x5f1dddbf348ac2fbe22a163e30f99f9ece3dd50a',
+            '0xc7a590291e07b9fe9e64b86c58fd8fc764308c4a'
+        ) --KyberSwap: Elastic Factory
         AND topics [0] :: STRING = '0x783cca1c0412dd0d695e784568c96da2e9c22ff989357a2e8b1d9b2b4e6b7118' --Create pool
 
 {% if is_incremental() %}

--- a/models/silver/dex/kyberswap/silver_dex__kyberswap_v2_elastic_pools.yml
+++ b/models/silver/dex/kyberswap/silver_dex__kyberswap_v2_elastic_pools.yml
@@ -1,0 +1,23 @@
+version: 2
+models:
+  - name: silver_dex__kyberswap_v2_elastic_pools
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - POOL_ADDRESS
+    columns:
+      - name: POOL_ADDRESS
+        tests:
+          - not_null
+      - name: TOKEN0
+        tests:
+          - not_null
+      - name: TOKEN1
+        tests:
+          - not_null
+      - name: _INSERTED_TIMESTAMP
+        tests: 
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - TIMESTAMP_LTZ
+                - TIMESTAMP_NTZ

--- a/models/silver/dex/kyberswap/silver_dex__kyberswap_v2_elastic_swaps.sql
+++ b/models/silver/dex/kyberswap/silver_dex__kyberswap_v2_elastic_swaps.sql
@@ -1,0 +1,117 @@
+{{ config(
+    materialized = 'incremental',
+    unique_key = '_log_id',
+    cluster_by = ['block_timestamp::DATE']
+) }}
+
+WITH pools AS (
+
+    SELECT
+        pool_address,
+        token0,
+        token1
+    FROM
+        {{ ref('silver_dex__kyberswap_v2_elastic_pools') }}
+),
+swaps_base AS (
+    SELECT
+        l.block_number,
+        l.block_timestamp,
+        l.tx_hash,
+        origin_function_signature,
+        origin_from_address,
+        origin_to_address,
+        l.event_index,
+        l.contract_address,
+        regexp_substr_all(SUBSTR(l.data, 3, len(l.data)), '.{64}') AS l_segmented_data,
+        CONCAT('0x', SUBSTR(l.topics [1] :: STRING, 27, 40)) AS sender_address,
+        CONCAT('0x', SUBSTR(l.topics [2] :: STRING, 27, 40)) AS reipient_address,
+        TRY_TO_NUMBER(
+            utils.udf_hex_to_int(
+                's2c',
+                l_segmented_data [0] :: STRING
+            )
+        ) AS deltaQty0,
+        TRY_TO_NUMBER(
+            utils.udf_hex_to_int(
+                's2c',
+                l_segmented_data [1] :: STRING
+            )
+        ) AS deltaQty1,
+        TRY_TO_NUMBER(
+            utils.udf_hex_to_int(
+                l_segmented_data [2] :: STRING
+            )
+        ) AS sqrtP,
+        TRY_TO_NUMBER(
+            utils.udf_hex_to_int(
+                l_segmented_data [3] :: STRING
+            )
+        ) AS liquidity,
+        TRY_TO_NUMBER(
+            utils.udf_hex_to_int(
+                's2c',
+                l_segmented_data [4] :: STRING
+            )
+        ) AS currentTick,
+        ABS(GREATEST(deltaQty0, deltaQty1)) AS amountOut,
+        ABS(LEAST(deltaQty0, deltaQty1)) AS amountIn,
+        token0,
+        token1,
+        CASE
+            WHEN deltaQty0 < 0 THEN token0
+            ELSE token1
+        END AS token_in,
+        CASE
+            WHEN deltaQty0 > 0 THEN token0
+            ELSE token1
+        END AS token_out,
+        l._log_id,
+        l._inserted_timestamp
+    FROM
+        {{ ref('silver__logs2') }}
+        l
+        INNER JOIN pools p
+        ON p.pool_address = l.contract_address
+    WHERE
+        topics [0] :: STRING = '0xc42079f94a6350d7e6235f29174924f928cc2ac818eb64fed8004e115fbcca67' -- elastic swap
+
+{% if is_incremental() %}
+AND _inserted_timestamp >= (
+    SELECT
+        MAX(_inserted_timestamp) :: DATE
+    FROM
+        {{ this }}
+)
+{% endif %}
+)
+SELECT
+    block_number,
+    block_timestamp,
+    tx_hash,
+    contract_address,
+    origin_function_signature,
+    origin_from_address,
+    origin_to_address,
+    event_index,
+    sender_address AS sender,
+    reipient_address AS tx_to,
+    deltaQty0 AS delta_qty0,
+    deltaQty1 AS delta_qty1,
+    sqrtP AS sqrt_p,
+    liquidity,
+    currentTick AS current_tick,
+    amountIn AS amount_in_unadj,
+    amountOut AS amount_out_unadj,
+    token0,
+    token1,
+    token_in,
+    token_out,
+    'Elastic Swap' AS event_name,
+    'kyberswap-v2' AS platform,
+    _log_id,
+    _inserted_timestamp
+FROM
+    swaps_base
+WHERE
+    token_in <> token_out

--- a/models/silver/dex/kyberswap/silver_dex__kyberswap_v2_elastic_swaps.sql
+++ b/models/silver/dex/kyberswap/silver_dex__kyberswap_v2_elastic_swaps.sql
@@ -69,7 +69,7 @@ swaps_base AS (
         l._log_id,
         l._inserted_timestamp
     FROM
-        {{ ref('silver__logs2') }}
+        {{ ref('silver__logs') }}
         l
         INNER JOIN pools p
         ON p.pool_address = l.contract_address

--- a/models/silver/dex/kyberswap/silver_dex__kyberswap_v2_elastic_swaps.yml
+++ b/models/silver/dex/kyberswap/silver_dex__kyberswap_v2_elastic_swaps.yml
@@ -1,0 +1,81 @@
+version: 2
+models:
+  - name: silver_dex__kyberswap_v2_elastic_swaps
+   
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - _LOG_ID
+    columns:
+      - name: BLOCK_NUMBER
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - FLOAT
+      - name: BLOCK_TIMESTAMP
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - TIMESTAMP_LTZ
+                - TIMESTAMP_NTZ
+      - name: TX_HASH
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: CONTRACT_ADDRESS
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: TOKEN_IN
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: TOKEN_OUT
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: SENDER
+        tests:
+          - not_null:
+              where: BLOCK_TIMESTAMP > '2021-08-01'
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: TX_TO
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: PLATFORM
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - STRING
+                - VARCHAR
+      - name: EVENT_INDEX
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - FLOAT
+      - name: _LOG_ID
+        tests:
+          - not_null
+      - name: ORIGIN_FUNCTION_SIGNATURE
+        tests:
+          - not_null
+      - name: ORIGIN_FROM_ADDRESS
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: ORIGIN_TO_ADDRESS
+        tests:
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+

--- a/models/silver/dex/silver_dex__complete_dex_swaps.sql
+++ b/models/silver/dex/silver_dex__complete_dex_swaps.sql
@@ -1,0 +1,1766 @@
+{{ config(
+  materialized = 'incremental',
+  unique_key = "_log_id",
+  cluster_by = ['block_timestamp::DATE']
+) }}
+
+WITH contracts AS (
+
+  SELECT
+    address,
+    symbol,
+    NAME,
+    decimals
+  FROM
+    {{ ref('core__dim_contracts') }}
+),
+prices AS (
+  SELECT
+    HOUR,
+    token_address,
+    price
+  FROM
+    {{ ref('core__fact_hourly_token_prices') }}
+  WHERE
+    token_address IN (
+      SELECT
+        DISTINCT address
+      FROM
+        contracts
+    )
+
+{% if is_incremental() %}
+AND HOUR >= (
+  SELECT
+    MAX(_inserted_timestamp) :: DATE - 2
+  FROM
+    {{ this }}
+)
+{% endif %}
+),
+univ3_swaps AS (
+  SELECT
+    block_number,
+    block_timestamp,
+    tx_hash,
+    origin_function_signature,
+    origin_from_address,
+    origin_to_address,
+    pool_address AS contract_address,
+    CONCAT(
+      c1.symbol,
+      '-',
+      c2.symbol,
+      ' ',
+      fee,
+      ' ',
+      tick_spacing
+    ) AS pool_name,
+    'Swap' AS event_name,
+    amount0_unadj / pow(10, COALESCE(c1.decimals, 18)) AS amount0_adjusted,
+    amount1_unadj / pow(10, COALESCE(c2.decimals, 18)) AS amount1_adjusted,
+    CASE
+      WHEN c1.decimals IS NOT NULL THEN ROUND(
+        p1.price * amount0_adjusted,
+        2
+      )
+    END AS amount0_usd,
+    CASE
+      WHEN c2.decimals IS NOT NULL THEN ROUND(
+        p2.price * amount1_adjusted,
+        2
+      )
+    END AS amount1_usd,
+    CASE
+      WHEN amount0_unadj > 0 THEN ABS(amount0_unadj)
+      ELSE ABS(amount1_unadj)
+    END AS amount_in_unadj,
+    CASE
+      WHEN amount0_unadj > 0 THEN ABS(amount0_adjusted)
+      ELSE ABS(amount1_adjusted)
+    END AS amount_in,
+    CASE
+      WHEN amount0_unadj > 0 THEN ABS(amount0_usd)
+      ELSE ABS(amount1_usd)
+    END AS amount_in_usd,
+    CASE
+      WHEN amount0_unadj < 0 THEN ABS(amount0_unadj)
+      ELSE ABS(amount1_unadj)
+    END AS amount_out_unadj,
+    CASE
+      WHEN amount0_unadj < 0 THEN ABS(amount0_adjusted)
+      ELSE ABS(amount1_adjusted)
+    END AS amount_out,
+    CASE
+      WHEN amount0_unadj < 0 THEN ABS(amount0_usd)
+      ELSE ABS(amount1_usd)
+    END AS amount_out_usd,
+    sender,
+    recipient AS tx_to,
+    event_index,
+    'uniswap-v3' AS platform,
+    CASE
+      WHEN amount0_unadj > 0 THEN token0_address
+      ELSE token1_address
+    END AS token_in,
+    CASE
+      WHEN amount0_unadj < 0 THEN token0_address
+      ELSE token1_address
+    END AS token_out,
+    CASE
+      WHEN amount0_unadj > 0 THEN c1.symbol
+      ELSE c2.symbol
+    END AS symbol_in,
+    CASE
+      WHEN amount0_unadj < 0 THEN c1.symbol
+      ELSE c2.symbol
+    END AS symbol_out,
+    _log_id,
+    _inserted_timestamp
+  FROM
+    {{ ref('silver_dex__univ3_swaps') }}
+    s
+    LEFT JOIN contracts c1
+    ON c1.address = s.token0_address
+    LEFT JOIN contracts c2
+    ON c2.address = s.token1_address
+    LEFT JOIN prices p1
+    ON s.token0_address = p1.token_address
+    AND DATE_TRUNC(
+      'hour',
+      block_timestamp
+    ) = p1.hour
+    LEFT JOIN prices p2
+    ON s.token1_address = p2.token_address
+    AND DATE_TRUNC(
+      'hour',
+      block_timestamp
+    ) = p2.hour
+
+{% if is_incremental() %}
+WHERE
+  _inserted_timestamp >= (
+    SELECT
+      MAX(_inserted_timestamp) :: DATE - 1
+    FROM
+      {{ this }}
+  )
+{% endif %}
+),
+balancer_swaps AS (
+  SELECT
+    block_number,
+    block_timestamp,
+    tx_hash,
+    origin_function_signature,
+    origin_from_address,
+    origin_to_address,
+    contract_address,
+    pool_name,
+    event_name,
+    c1.decimals AS decimals_in,
+    c1.symbol AS symbol_in,
+    amount_in_unadj,
+    CASE
+      WHEN decimals_in IS NULL THEN amount_in_unadj
+      ELSE (amount_in_unadj / pow(10, decimals_in))
+    END AS amount_in,
+    c2.decimals AS decimals_out,
+    c2.symbol AS symbol_out,
+    amount_out_unadj,
+    CASE
+      WHEN decimals_out IS NULL THEN amount_out_unadj
+      ELSE (amount_out_unadj / pow(10, decimals_out))
+    END AS amount_out,
+    sender,
+    tx_to,
+    event_index,
+    platform,
+    token_in,
+    token_out,
+    _log_id,
+    _inserted_timestamp
+  FROM
+    {{ ref('silver_dex__balancer_swaps') }}
+    s
+    LEFT JOIN contracts c1
+    ON s.token_in = c1.address
+    LEFT JOIN contracts c2
+    ON s.token_out = c2.address
+
+{% if is_incremental() %}
+WHERE
+  _inserted_timestamp >= (
+    SELECT
+      MAX(_inserted_timestamp) :: DATE - 1
+    FROM
+      {{ this }}
+  )
+{% endif %}
+),
+curve_swaps AS (
+  SELECT
+    block_number,
+    block_timestamp,
+    tx_hash,
+    origin_function_signature,
+    origin_from_address,
+    origin_to_address,
+    contract_address,
+    event_name,
+    s.tokens_sold AS amount_in_unadj,
+    s.tokens_bought AS amount_out_unadj,
+    sender,
+    tx_to,
+    event_index,
+    platform,
+    token_in,
+    token_out,
+    COALESCE(
+      c1.symbol,
+      s.symbol_in
+    ) AS token_symbol_in,
+    COALESCE(
+      c2.symbol,
+      s.symbol_out
+    ) AS token_symbol_out,
+    pool_name,
+    c1.decimals AS decimals_in,
+    CASE
+      WHEN decimals_in IS NOT NULL THEN s.tokens_sold / pow(
+        10,
+        decimals_in
+      )
+      ELSE s.tokens_sold
+    END AS amount_in,
+    c2.decimals AS decimals_out,
+    CASE
+      WHEN decimals_out IS NOT NULL THEN s.tokens_bought / pow(
+        10,
+        decimals_out
+      )
+      ELSE s.tokens_bought
+    END AS amount_out,
+    _log_id,
+    _inserted_timestamp
+  FROM
+    {{ ref('silver_dex__curve_swaps') }}
+    s
+    LEFT JOIN contracts c1
+    ON c1.address = s.token_in
+    LEFT JOIN contracts c2
+    ON c2.address = s.token_out
+  WHERE
+    amount_out <> 0
+    AND COALESCE(
+      token_symbol_in,
+      'null'
+    ) <> COALESCE(token_symbol_out, 'null')
+
+{% if is_incremental() %}
+AND _inserted_timestamp >= (
+  SELECT
+    MAX(_inserted_timestamp) :: DATE
+  FROM
+    {{ this }}
+)
+{% endif %}
+),
+trader_joe_v1_swaps AS (
+  SELECT
+    block_number,
+    block_timestamp,
+    tx_hash,
+    origin_function_signature,
+    origin_from_address,
+    origin_to_address,
+    contract_address,
+    event_name,
+    c1.decimals AS decimals_in,
+    c1.symbol AS symbol_in,
+    amount_in_unadj,
+    CASE
+      WHEN decimals_in IS NULL THEN amount_in_unadj
+      ELSE (amount_in_unadj / pow(10, decimals_in))
+    END AS amount_in,
+    c2.decimals AS decimals_out,
+    c2.symbol AS symbol_out,
+    amount_out_unadj,
+    CASE
+      WHEN decimals_out IS NULL THEN amount_out_unadj
+      ELSE (amount_out_unadj / pow(10, decimals_out))
+    END AS amount_out,
+    sender,
+    tx_to,
+    event_index,
+    platform,
+    token_in,
+    token_out,
+    CONCAT(LEAST(symbol_in, symbol_out), '-', GREATEST(symbol_in, symbol_out)) AS pool_name,
+    _log_id,
+    _inserted_timestamp
+  FROM
+    {{ ref('silver_dex__trader_joe_v1_swaps') }}
+    s
+    LEFT JOIN contracts c1
+    ON s.token_in = c1.address
+    LEFT JOIN contracts c2
+    ON s.token_out = c2.address
+
+{% if is_incremental() %}
+WHERE
+  _inserted_timestamp >= (
+    SELECT
+      MAX(_inserted_timestamp) :: DATE - 1
+    FROM
+      {{ this }}
+  )
+{% endif %}
+),
+trader_joe_v2_swaps AS (
+  SELECT
+    block_number,
+    block_timestamp,
+    tx_hash,
+    origin_function_signature,
+    origin_from_address,
+    origin_to_address,
+    contract_address,
+    event_name,
+    c1.decimals AS decimals_in,
+    c1.symbol AS symbol_in,
+    amount_in_unadj,
+    CASE
+      WHEN decimals_in IS NULL THEN amount_in_unadj
+      ELSE (amount_in_unadj / pow(10, decimals_in))
+    END AS amount_in,
+    c2.decimals AS decimals_out,
+    c2.symbol AS symbol_out,
+    amount_out_unadj,
+    CASE
+      WHEN decimals_out IS NULL THEN amount_out_unadj
+      ELSE (amount_out_unadj / pow(10, decimals_out))
+    END AS amount_out,
+    sender,
+    tx_to,
+    event_index,
+    platform,
+    token_in,
+    token_out,
+    CONCAT(LEAST(symbol_in, symbol_out), '-', GREATEST(symbol_in, symbol_out)) AS pool_name,
+    _log_id,
+    _inserted_timestamp
+  FROM
+    {{ ref('silver_dex__trader_joe_v2_swaps') }}
+    s
+    LEFT JOIN contracts c1
+    ON s.token_in = c1.address
+    LEFT JOIN contracts c2
+    ON s.token_out = c2.address
+
+{% if is_incremental() %}
+WHERE
+  _inserted_timestamp >= (
+    SELECT
+      MAX(_inserted_timestamp) :: DATE - 1
+    FROM
+      {{ this }}
+  )
+{% endif %}
+),
+trader_joe_v2_1_swaps AS (
+  SELECT
+    block_number,
+    block_timestamp,
+    tx_hash,
+    origin_function_signature,
+    origin_from_address,
+    origin_to_address,
+    contract_address,
+    event_name,
+    c1.decimals AS decimals_in,
+    c1.symbol AS symbol_in,
+    amount_in_unadj,
+    CASE
+      WHEN decimals_in IS NULL THEN amount_in_unadj
+      ELSE (amount_in_unadj / pow(10, decimals_in))
+    END AS amount_in,
+    c2.decimals AS decimals_out,
+    c2.symbol AS symbol_out,
+    amount_out_unadj,
+    CASE
+      WHEN decimals_out IS NULL THEN amount_out_unadj
+      ELSE (amount_out_unadj / pow(10, decimals_out))
+    END AS amount_out,
+    sender,
+    tx_to,
+    event_index,
+    platform,
+    token_in,
+    token_out,
+    CONCAT(LEAST(symbol_in, symbol_out), '-', GREATEST(symbol_in, symbol_out)) AS pool_name,
+    _log_id,
+    _inserted_timestamp
+  FROM
+    {{ ref('silver_dex__trader_joe_v2_1_swaps') }}
+    s
+    LEFT JOIN contracts c1
+    ON s.token_in = c1.address
+    LEFT JOIN contracts c2
+    ON s.token_out = c2.address
+
+{% if is_incremental() %}
+WHERE
+  _inserted_timestamp >= (
+    SELECT
+      MAX(_inserted_timestamp) :: DATE - 1
+    FROM
+      {{ this }}
+  )
+{% endif %}
+),
+woofi_swaps AS (
+  SELECT
+    block_number,
+    block_timestamp,
+    tx_hash,
+    origin_function_signature,
+    origin_from_address,
+    origin_to_address,
+    contract_address,
+    event_name,
+    c1.decimals AS decimals_in,
+    c1.symbol AS symbol_in,
+    amount_in_unadj,
+    CASE
+      WHEN decimals_in IS NULL THEN amount_in_unadj
+      ELSE (amount_in_unadj / pow(10, decimals_in))
+    END AS amount_in,
+    c2.decimals AS decimals_out,
+    c2.symbol AS symbol_out,
+    amount_out_unadj,
+    CASE
+      WHEN decimals_out IS NULL THEN amount_out_unadj
+      ELSE (amount_out_unadj / pow(10, decimals_out))
+    END AS amount_out,
+    sender,
+    tx_to,
+    event_index,
+    platform,
+    token_in,
+    token_out,
+    CONCAT(LEAST(symbol_in, symbol_out), '-', GREATEST(symbol_in, symbol_out)) AS pool_name,
+    _log_id,
+    _inserted_timestamp
+  FROM
+    {{ ref('silver_dex__woofi_swaps') }}
+    s
+    LEFT JOIN contracts c1
+    ON s.token_in = c1.address
+    LEFT JOIN contracts c2
+    ON s.token_out = c2.address
+
+{% if is_incremental() %}
+WHERE
+  _inserted_timestamp >= (
+    SELECT
+      MAX(_inserted_timestamp) :: DATE - 1
+    FROM
+      {{ this }}
+  )
+{% endif %}
+),
+gmx_swaps AS (
+  SELECT
+    block_number,
+    block_timestamp,
+    tx_hash,
+    origin_function_signature,
+    origin_from_address,
+    origin_to_address,
+    contract_address,
+    event_name,
+    c1.decimals AS decimals_in,
+    c1.symbol AS symbol_in,
+    amount_in_unadj,
+    CASE
+      WHEN decimals_in IS NULL THEN amount_in_unadj
+      ELSE (amount_in_unadj / pow(10, decimals_in))
+    END AS amount_in,
+    c2.decimals AS decimals_out,
+    c2.symbol AS symbol_out,
+    amount_out_unadj,
+    CASE
+      WHEN decimals_out IS NULL THEN amount_out_unadj
+      ELSE (amount_out_unadj / pow(10, decimals_out))
+    END AS amount_out,
+    sender,
+    tx_to,
+    event_index,
+    platform,
+    token_in,
+    token_out,
+    CONCAT(LEAST(symbol_in, symbol_out), '-', GREATEST(symbol_in, symbol_out)) AS pool_name,
+    _log_id,
+    _inserted_timestamp
+  FROM
+    {{ ref('silver_dex__gmx_swaps') }}
+    s
+    LEFT JOIN contracts c1
+    ON s.token_in = c1.address
+    LEFT JOIN contracts c2
+    ON s.token_out = c2.address
+
+{% if is_incremental() %}
+WHERE
+  _inserted_timestamp >= (
+    SELECT
+      MAX(_inserted_timestamp) :: DATE - 1
+    FROM
+      {{ this }}
+  )
+{% endif %}
+),
+kyberswap_v1_dynamic AS (
+  SELECT
+    block_number,
+    block_timestamp,
+    tx_hash,
+    origin_function_signature,
+    origin_from_address,
+    origin_to_address,
+    contract_address,
+    event_name,
+    c1.decimals AS decimals_in,
+    c1.symbol AS symbol_in,
+    amount_in_unadj,
+    CASE
+      WHEN decimals_in IS NULL THEN amount_in_unadj
+      ELSE (amount_in_unadj / pow(10, decimals_in))
+    END AS amount_in,
+    c2.decimals AS decimals_out,
+    c2.symbol AS symbol_out,
+    amount_out_unadj,
+    CASE
+      WHEN decimals_out IS NULL THEN amount_out_unadj
+      ELSE (amount_out_unadj / pow(10, decimals_out))
+    END AS amount_out,
+    sender,
+    tx_to,
+    event_index,
+    platform,
+    token_in,
+    token_out,
+    CONCAT(LEAST(symbol_in, symbol_out), '-', GREATEST(symbol_in, symbol_out)) AS pool_name,
+    _log_id,
+    _inserted_timestamp
+  FROM
+    {{ ref('silver_dex__kyberswap_v1_dynamic_swaps') }}
+    s
+    LEFT JOIN contracts c1
+    ON s.token_in = c1.address
+    LEFT JOIN contracts c2
+    ON s.token_out = c2.address
+
+{% if is_incremental() %}
+WHERE
+  _inserted_timestamp >= (
+    SELECT
+      MAX(_inserted_timestamp) :: DATE - 1
+    FROM
+      {{ this }}
+  )
+{% endif %}
+),
+kyberswap_v1_static AS (
+  SELECT
+    block_number,
+    block_timestamp,
+    tx_hash,
+    origin_function_signature,
+    origin_from_address,
+    origin_to_address,
+    contract_address,
+    event_name,
+    c1.decimals AS decimals_in,
+    c1.symbol AS symbol_in,
+    amount_in_unadj,
+    CASE
+      WHEN decimals_in IS NULL THEN amount_in_unadj
+      ELSE (amount_in_unadj / pow(10, decimals_in))
+    END AS amount_in,
+    c2.decimals AS decimals_out,
+    c2.symbol AS symbol_out,
+    amount_out_unadj,
+    CASE
+      WHEN decimals_out IS NULL THEN amount_out_unadj
+      ELSE (amount_out_unadj / pow(10, decimals_out))
+    END AS amount_out,
+    sender,
+    tx_to,
+    event_index,
+    platform,
+    token_in,
+    token_out,
+    CONCAT(LEAST(symbol_in, symbol_out), '-', GREATEST(symbol_in, symbol_out)) AS pool_name,
+    _log_id,
+    _inserted_timestamp
+  FROM
+    {{ ref('silver_dex__kyberswap_v1_static_swaps') }}
+    s
+    LEFT JOIN contracts c1
+    ON s.token_in = c1.address
+    LEFT JOIN contracts c2
+    ON s.token_out = c2.address
+
+{% if is_incremental() %}
+WHERE
+  _inserted_timestamp >= (
+    SELECT
+      MAX(_inserted_timestamp) :: DATE - 1
+    FROM
+      {{ this }}
+  )
+{% endif %}
+),
+kyberswap_v2_elastic AS (
+  SELECT
+    block_number,
+    block_timestamp,
+    tx_hash,
+    origin_function_signature,
+    origin_from_address,
+    origin_to_address,
+    contract_address,
+    event_name,
+    c1.decimals AS decimals_in,
+    c1.symbol AS symbol_in,
+    amount_in_unadj,
+    CASE
+      WHEN decimals_in IS NULL THEN amount_in_unadj
+      ELSE (amount_in_unadj / pow(10, decimals_in))
+    END AS amount_in,
+    c2.decimals AS decimals_out,
+    c2.symbol AS symbol_out,
+    amount_out_unadj,
+    CASE
+      WHEN decimals_out IS NULL THEN amount_out_unadj
+      ELSE (amount_out_unadj / pow(10, decimals_out))
+    END AS amount_out,
+    sender,
+    tx_to,
+    event_index,
+    platform,
+    token_in,
+    token_out,
+    CONCAT(LEAST(symbol_in, symbol_out), '-', GREATEST(symbol_in, symbol_out)) AS pool_name,
+    _log_id,
+    _inserted_timestamp
+  FROM
+    {{ ref('silver_dex__kyberswap_v2_elastic_swaps') }}
+    s
+    LEFT JOIN contracts c1
+    ON s.token_in = c1.address
+    LEFT JOIN contracts c2
+    ON s.token_out = c2.address
+
+{% if is_incremental() %}
+WHERE
+  _inserted_timestamp >= (
+    SELECT
+      MAX(_inserted_timestamp) :: DATE - 1
+    FROM
+      {{ this }}
+  )
+{% endif %}
+),
+fraxswap_swaps AS (
+  SELECT
+    block_number,
+    block_timestamp,
+    tx_hash,
+    origin_function_signature,
+    origin_from_address,
+    origin_to_address,
+    contract_address,
+    event_name,
+    c1.decimals AS decimals_in,
+    c1.symbol AS symbol_in,
+    amount_in_unadj,
+    CASE
+      WHEN decimals_in IS NULL THEN amount_in_unadj
+      ELSE (amount_in_unadj / pow(10, decimals_in))
+    END AS amount_in,
+    c2.decimals AS decimals_out,
+    c2.symbol AS symbol_out,
+    amount_out_unadj,
+    CASE
+      WHEN decimals_out IS NULL THEN amount_out_unadj
+      ELSE (amount_out_unadj / pow(10, decimals_out))
+    END AS amount_out,
+    sender,
+    tx_to,
+    event_index,
+    platform,
+    token_in,
+    token_out,
+    CONCAT(LEAST(symbol_in, symbol_out), '-', GREATEST(symbol_in, symbol_out)) AS pool_name,
+    _log_id,
+    _inserted_timestamp
+  FROM
+    {{ ref('silver_dex__fraxswap_swaps') }}
+    s
+    LEFT JOIN contracts c1
+    ON s.token_in = c1.address
+    LEFT JOIN contracts c2
+    ON s.token_out = c2.address
+
+{% if is_incremental() %}
+WHERE
+  _inserted_timestamp >= (
+    SELECT
+      MAX(_inserted_timestamp) :: DATE - 1
+    FROM
+      {{ this }}
+  )
+{% endif %}
+),
+sushi_swaps AS (
+  SELECT
+    block_number,
+    block_timestamp,
+    tx_hash,
+    origin_function_signature,
+    origin_from_address,
+    origin_to_address,
+    contract_address,
+    event_name,
+    c1.decimals AS decimals_in,
+    c1.symbol AS symbol_in,
+    amount_in_unadj,
+    CASE
+      WHEN decimals_in IS NULL THEN amount_in_unadj
+      ELSE (amount_in_unadj / pow(10, decimals_in))
+    END AS amount_in,
+    c2.decimals AS decimals_out,
+    c2.symbol AS symbol_out,
+    amount_out_unadj,
+    CASE
+      WHEN decimals_out IS NULL THEN amount_out_unadj
+      ELSE (amount_out_unadj / pow(10, decimals_out))
+    END AS amount_out,
+    sender,
+    tx_to,
+    event_index,
+    platform,
+    token_in,
+    token_out,
+    CONCAT(LEAST(symbol_in, symbol_out), '-', GREATEST(symbol_in, symbol_out)) AS pool_name,
+    _log_id,
+    _inserted_timestamp
+  FROM
+    {{ ref('silver_dex__sushi_swaps') }}
+    s
+    LEFT JOIN contracts c1
+    ON s.token_in = c1.address
+    LEFT JOIN contracts c2
+    ON s.token_out = c2.address
+
+{% if is_incremental() %}
+WHERE
+  _inserted_timestamp >= (
+    SELECT
+      MAX(_inserted_timestamp) :: DATE - 1
+    FROM
+      {{ this }}
+  )
+{% endif %}
+),
+dodo_v1_swaps AS (
+  SELECT
+    block_number,
+    block_timestamp,
+    tx_hash,
+    origin_function_signature,
+    origin_from_address,
+    origin_to_address,
+    contract_address,
+    event_name,
+    c1.decimals AS decimals_in,
+    c1.symbol AS symbol_in,
+    amount_in_unadj,
+    CASE
+      WHEN decimals_in IS NULL THEN amount_in_unadj
+      ELSE (amount_in_unadj / pow(10, decimals_in))
+    END AS amount_in,
+    c2.decimals AS decimals_out,
+    c2.symbol AS symbol_out,
+    amount_out_unadj,
+    CASE
+      WHEN decimals_out IS NULL THEN amount_out_unadj
+      ELSE (amount_out_unadj / pow(10, decimals_out))
+    END AS amount_out,
+    sender,
+    tx_to,
+    event_index,
+    platform,
+    token_in,
+    token_out,
+    CONCAT(LEAST(symbol_in, symbol_out), '-', GREATEST(symbol_in, symbol_out)) AS pool_name,
+    _log_id,
+    _inserted_timestamp
+  FROM
+    {{ ref('silver_dex__dodo_v1_swaps') }}
+    s
+    LEFT JOIN contracts c1
+    ON s.token_in = c1.address
+    LEFT JOIN contracts c2
+    ON s.token_out = c2.address
+
+{% if is_incremental() %}
+WHERE
+  _inserted_timestamp >= (
+    SELECT
+      MAX(_inserted_timestamp) :: DATE - 1
+    FROM
+      {{ this }}
+  )
+{% endif %}
+),
+dodo_v2_swaps AS (
+  SELECT
+    block_number,
+    block_timestamp,
+    tx_hash,
+    origin_function_signature,
+    origin_from_address,
+    origin_to_address,
+    contract_address,
+    event_name,
+    c1.decimals AS decimals_in,
+    c1.symbol AS symbol_in,
+    amount_in_unadj,
+    CASE
+      WHEN decimals_in IS NULL THEN amount_in_unadj
+      ELSE (amount_in_unadj / pow(10, decimals_in))
+    END AS amount_in,
+    c2.decimals AS decimals_out,
+    c2.symbol AS symbol_out,
+    amount_out_unadj,
+    CASE
+      WHEN decimals_out IS NULL THEN amount_out_unadj
+      ELSE (amount_out_unadj / pow(10, decimals_out))
+    END AS amount_out,
+    sender,
+    tx_to,
+    event_index,
+    platform,
+    token_in,
+    token_out,
+    CONCAT(LEAST(symbol_in, symbol_out), '-', GREATEST(symbol_in, symbol_out)) AS pool_name,
+    _log_id,
+    _inserted_timestamp
+  FROM
+    {{ ref('silver_dex__dodo_v2_swaps') }}
+    s
+    LEFT JOIN contracts c1
+    ON s.token_in = c1.address
+    LEFT JOIN contracts c2
+    ON s.token_out = c2.address
+
+{% if is_incremental() %}
+WHERE
+  _inserted_timestamp >= (
+    SELECT
+      MAX(_inserted_timestamp) :: DATE - 1
+    FROM
+      {{ this }}
+  )
+{% endif %}
+),
+camelot_v2_swaps AS (
+  SELECT
+    block_number,
+    block_timestamp,
+    tx_hash,
+    origin_function_signature,
+    origin_from_address,
+    origin_to_address,
+    contract_address,
+    event_name,
+    c1.decimals AS decimals_in,
+    c1.symbol AS symbol_in,
+    amount_in_unadj,
+    CASE
+      WHEN decimals_in IS NULL THEN amount_in_unadj
+      ELSE (amount_in_unadj / pow(10, decimals_in))
+    END AS amount_in,
+    c2.decimals AS decimals_out,
+    c2.symbol AS symbol_out,
+    amount_out_unadj,
+    CASE
+      WHEN decimals_out IS NULL THEN amount_out_unadj
+      ELSE (amount_out_unadj / pow(10, decimals_out))
+    END AS amount_out,
+    sender,
+    tx_to,
+    event_index,
+    platform,
+    token_in,
+    token_out,
+    CONCAT(LEAST(symbol_in, symbol_out), '-', GREATEST(symbol_in, symbol_out)) AS pool_name,
+    _log_id,
+    _inserted_timestamp
+  FROM
+    {{ ref('silver_dex__camelot_v2_swaps') }}
+    s
+    LEFT JOIN contracts c1
+    ON s.token_in = c1.address
+    LEFT JOIN contracts c2
+    ON s.token_out = c2.address
+
+{% if is_incremental() %}
+WHERE
+  _inserted_timestamp >= (
+    SELECT
+      MAX(_inserted_timestamp) :: DATE - 1
+    FROM
+      {{ this }}
+  )
+{% endif %}
+),
+camelot_v3_swaps AS (
+  SELECT
+    block_number,
+    block_timestamp,
+    tx_hash,
+    origin_function_signature,
+    origin_from_address,
+    origin_to_address,
+    contract_address,
+    event_name,
+    c1.decimals AS decimals_in,
+    c1.symbol AS symbol_in,
+    amount_in_unadj,
+    CASE
+      WHEN decimals_in IS NULL THEN amount_in_unadj
+      ELSE (amount_in_unadj / pow(10, decimals_in))
+    END AS amount_in,
+    c2.decimals AS decimals_out,
+    c2.symbol AS symbol_out,
+    amount_out_unadj,
+    CASE
+      WHEN decimals_out IS NULL THEN amount_out_unadj
+      ELSE (amount_out_unadj / pow(10, decimals_out))
+    END AS amount_out,
+    sender,
+    tx_to,
+    event_index,
+    platform,
+    token_in,
+    token_out,
+    CONCAT(LEAST(symbol_in, symbol_out), '-', GREATEST(symbol_in, symbol_out)) AS pool_name,
+    _log_id,
+    _inserted_timestamp
+  FROM
+    {{ ref('silver_dex__camelot_v3_swaps') }}
+    s
+    LEFT JOIN contracts c1
+    ON s.token_in = c1.address
+    LEFT JOIN contracts c2
+    ON s.token_out = c2.address
+
+{% if is_incremental() %}
+WHERE
+  _inserted_timestamp >= (
+    SELECT
+      MAX(_inserted_timestamp) :: DATE - 1
+    FROM
+      {{ this }}
+  )
+{% endif %}
+),
+zyberswap_v2_swaps AS (
+  SELECT
+    block_number,
+    block_timestamp,
+    tx_hash,
+    origin_function_signature,
+    origin_from_address,
+    origin_to_address,
+    contract_address,
+    event_name,
+    c1.decimals AS decimals_in,
+    c1.symbol AS symbol_in,
+    amount_in_unadj,
+    CASE
+      WHEN decimals_in IS NULL THEN amount_in_unadj
+      ELSE (amount_in_unadj / pow(10, decimals_in))
+    END AS amount_in,
+    c2.decimals AS decimals_out,
+    c2.symbol AS symbol_out,
+    amount_out_unadj,
+    CASE
+      WHEN decimals_out IS NULL THEN amount_out_unadj
+      ELSE (amount_out_unadj / pow(10, decimals_out))
+    END AS amount_out,
+    sender,
+    tx_to,
+    event_index,
+    platform,
+    token_in,
+    token_out,
+    CONCAT(LEAST(symbol_in, symbol_out), '-', GREATEST(symbol_in, symbol_out)) AS pool_name,
+    _log_id,
+    _inserted_timestamp
+  FROM
+    {{ ref('silver_dex__zyberswap_v2_swaps') }}
+    s
+    LEFT JOIN contracts c1
+    ON s.token_in = c1.address
+    LEFT JOIN contracts c2
+    ON s.token_out = c2.address
+
+{% if is_incremental() %}
+WHERE
+  _inserted_timestamp >= (
+    SELECT
+      MAX(_inserted_timestamp) :: DATE - 1
+    FROM
+      {{ this }}
+  )
+{% endif %}
+),
+zyberswap_v3_swaps AS (
+  SELECT
+    block_number,
+    block_timestamp,
+    tx_hash,
+    origin_function_signature,
+    origin_from_address,
+    origin_to_address,
+    contract_address,
+    event_name,
+    c1.decimals AS decimals_in,
+    c1.symbol AS symbol_in,
+    amount_in_unadj,
+    CASE
+      WHEN decimals_in IS NULL THEN amount_in_unadj
+      ELSE (amount_in_unadj / pow(10, decimals_in))
+    END AS amount_in,
+    c2.decimals AS decimals_out,
+    c2.symbol AS symbol_out,
+    amount_out_unadj,
+    CASE
+      WHEN decimals_out IS NULL THEN amount_out_unadj
+      ELSE (amount_out_unadj / pow(10, decimals_out))
+    END AS amount_out,
+    sender,
+    tx_to,
+    event_index,
+    platform,
+    token_in,
+    token_out,
+    CONCAT(LEAST(symbol_in, symbol_out), '-', GREATEST(symbol_in, symbol_out)) AS pool_name,
+    _log_id,
+    _inserted_timestamp
+  FROM
+    {{ ref('silver_dex__zyberswap_v3_swaps') }}
+    s
+    LEFT JOIN contracts c1
+    ON s.token_in = c1.address
+    LEFT JOIN contracts c2
+    ON s.token_out = c2.address
+
+{% if is_incremental() %}
+WHERE
+  _inserted_timestamp >= (
+    SELECT
+      MAX(_inserted_timestamp) :: DATE - 1
+    FROM
+      {{ this }}
+  )
+{% endif %}
+),
+--union all standard dex CTEs here (excludes amount_usd)
+all_dex_standard AS (
+  SELECT
+    block_number,
+    block_timestamp,
+    tx_hash,
+    origin_function_signature,
+    origin_from_address,
+    origin_to_address,
+    contract_address,
+    pool_name,
+    event_name,
+    amount_in_unadj,
+    amount_out_unadj,
+    amount_in,
+    amount_out,
+    sender,
+    tx_to,
+    event_index,
+    platform,
+    token_in,
+    token_out,
+    symbol_in,
+    symbol_out,
+    decimals_in,
+    decimals_out,
+    _log_id,
+    _inserted_timestamp
+  FROM
+    balancer_swaps
+  UNION ALL
+  SELECT
+    block_number,
+    block_timestamp,
+    tx_hash,
+    origin_function_signature,
+    origin_from_address,
+    origin_to_address,
+    contract_address,
+    pool_name,
+    event_name,
+    amount_in_unadj,
+    amount_out_unadj,
+    amount_in,
+    amount_out,
+    sender,
+    tx_to,
+    event_index,
+    platform,
+    token_in,
+    token_out,
+    symbol_in,
+    symbol_out,
+    decimals_in,
+    decimals_out,
+    _log_id,
+    _inserted_timestamp
+  FROM
+    camelot_v2_swaps
+  UNION ALL
+  SELECT
+    block_number,
+    block_timestamp,
+    tx_hash,
+    origin_function_signature,
+    origin_from_address,
+    origin_to_address,
+    contract_address,
+    pool_name,
+    event_name,
+    amount_in_unadj,
+    amount_out_unadj,
+    amount_in,
+    amount_out,
+    sender,
+    tx_to,
+    event_index,
+    platform,
+    token_in,
+    token_out,
+    symbol_in,
+    symbol_out,
+    decimals_in,
+    decimals_out,
+    _log_id,
+    _inserted_timestamp
+  FROM
+    camelot_v3_swaps
+  UNION ALL
+  SELECT
+    block_number,
+    block_timestamp,
+    tx_hash,
+    origin_function_signature,
+    origin_from_address,
+    origin_to_address,
+    contract_address,
+    pool_name,
+    event_name,
+    amount_in_unadj,
+    amount_out_unadj,
+    amount_in,
+    amount_out,
+    sender,
+    tx_to,
+    event_index,
+    platform,
+    token_in,
+    token_out,
+    token_symbol_in AS symbol_in,
+    token_symbol_out AS symbol_out,
+    decimals_in,
+    decimals_out,
+    _log_id,
+    _inserted_timestamp
+  FROM
+    curve_swaps
+  UNION ALL
+  SELECT
+    block_number,
+    block_timestamp,
+    tx_hash,
+    origin_function_signature,
+    origin_from_address,
+    origin_to_address,
+    contract_address,
+    pool_name,
+    event_name,
+    amount_in_unadj,
+    amount_out_unadj,
+    amount_in,
+    amount_out,
+    sender,
+    tx_to,
+    event_index,
+    platform,
+    token_in,
+    token_out,
+    symbol_in,
+    symbol_out,
+    decimals_in,
+    decimals_out,
+    _log_id,
+    _inserted_timestamp
+  FROM
+    dodo_v1_swaps
+  UNION ALL
+  SELECT
+    block_number,
+    block_timestamp,
+    tx_hash,
+    origin_function_signature,
+    origin_from_address,
+    origin_to_address,
+    contract_address,
+    pool_name,
+    event_name,
+    amount_in_unadj,
+    amount_out_unadj,
+    amount_in,
+    amount_out,
+    sender,
+    tx_to,
+    event_index,
+    platform,
+    token_in,
+    token_out,
+    symbol_in,
+    symbol_out,
+    decimals_in,
+    decimals_out,
+    _log_id,
+    _inserted_timestamp
+  FROM
+    dodo_v2_swaps
+  UNION ALL
+  SELECT
+    block_number,
+    block_timestamp,
+    tx_hash,
+    origin_function_signature,
+    origin_from_address,
+    origin_to_address,
+    contract_address,
+    pool_name,
+    event_name,
+    amount_in_unadj,
+    amount_out_unadj,
+    amount_in,
+    amount_out,
+    sender,
+    tx_to,
+    event_index,
+    platform,
+    token_in,
+    token_out,
+    symbol_in,
+    symbol_out,
+    decimals_in,
+    decimals_out,
+    _log_id,
+    _inserted_timestamp
+  FROM
+    fraxswap_swaps
+  UNION ALL
+  SELECT
+    block_number,
+    block_timestamp,
+    tx_hash,
+    origin_function_signature,
+    origin_from_address,
+    origin_to_address,
+    contract_address,
+    pool_name,
+    event_name,
+    amount_in_unadj,
+    amount_out_unadj,
+    amount_in,
+    amount_out,
+    sender,
+    tx_to,
+    event_index,
+    platform,
+    token_in,
+    token_out,
+    symbol_in,
+    symbol_out,
+    decimals_in,
+    decimals_out,
+    _log_id,
+    _inserted_timestamp
+  FROM
+    gmx_swaps
+  UNION ALL
+  SELECT
+    block_number,
+    block_timestamp,
+    tx_hash,
+    origin_function_signature,
+    origin_from_address,
+    origin_to_address,
+    contract_address,
+    pool_name,
+    event_name,
+    amount_in_unadj,
+    amount_out_unadj,
+    amount_in,
+    amount_out,
+    sender,
+    tx_to,
+    event_index,
+    platform,
+    token_in,
+    token_out,
+    symbol_in,
+    symbol_out,
+    decimals_in,
+    decimals_out,
+    _log_id,
+    _inserted_timestamp
+  FROM
+    kyberswap_v1_dynamic
+  UNION ALL
+  SELECT
+    block_number,
+    block_timestamp,
+    tx_hash,
+    origin_function_signature,
+    origin_from_address,
+    origin_to_address,
+    contract_address,
+    pool_name,
+    event_name,
+    amount_in_unadj,
+    amount_out_unadj,
+    amount_in,
+    amount_out,
+    sender,
+    tx_to,
+    event_index,
+    platform,
+    token_in,
+    token_out,
+    symbol_in,
+    symbol_out,
+    decimals_in,
+    decimals_out,
+    _log_id,
+    _inserted_timestamp
+  FROM
+    kyberswap_v1_static
+  UNION ALL
+  SELECT
+    block_number,
+    block_timestamp,
+    tx_hash,
+    origin_function_signature,
+    origin_from_address,
+    origin_to_address,
+    contract_address,
+    pool_name,
+    event_name,
+    amount_in_unadj,
+    amount_out_unadj,
+    amount_in,
+    amount_out,
+    sender,
+    tx_to,
+    event_index,
+    platform,
+    token_in,
+    token_out,
+    symbol_in,
+    symbol_out,
+    decimals_in,
+    decimals_out,
+    _log_id,
+    _inserted_timestamp
+  FROM
+    kyberswap_v2_elastic
+  UNION ALL
+  SELECT
+    block_number,
+    block_timestamp,
+    tx_hash,
+    origin_function_signature,
+    origin_from_address,
+    origin_to_address,
+    contract_address,
+    pool_name,
+    event_name,
+    amount_in_unadj,
+    amount_out_unadj,
+    amount_in,
+    amount_out,
+    sender,
+    tx_to,
+    event_index,
+    platform,
+    token_in,
+    token_out,
+    symbol_in,
+    symbol_out,
+    decimals_in,
+    decimals_out,
+    _log_id,
+    _inserted_timestamp
+  FROM
+    sushi_swaps
+  UNION ALL
+  SELECT
+    block_number,
+    block_timestamp,
+    tx_hash,
+    origin_function_signature,
+    origin_from_address,
+    origin_to_address,
+    contract_address,
+    pool_name,
+    event_name,
+    amount_in_unadj,
+    amount_out_unadj,
+    amount_in,
+    amount_out,
+    sender,
+    tx_to,
+    event_index,
+    platform,
+    token_in,
+    token_out,
+    symbol_in,
+    symbol_out,
+    decimals_in,
+    decimals_out,
+    _log_id,
+    _inserted_timestamp
+  FROM
+    trader_joe_v1_swaps
+  UNION ALL
+  SELECT
+    block_number,
+    block_timestamp,
+    tx_hash,
+    origin_function_signature,
+    origin_from_address,
+    origin_to_address,
+    contract_address,
+    pool_name,
+    event_name,
+    amount_in_unadj,
+    amount_out_unadj,
+    amount_in,
+    amount_out,
+    sender,
+    tx_to,
+    event_index,
+    platform,
+    token_in,
+    token_out,
+    symbol_in,
+    symbol_out,
+    decimals_in,
+    decimals_out,
+    _log_id,
+    _inserted_timestamp
+  FROM
+    trader_joe_v2_1_swaps
+  UNION ALL
+  SELECT
+    block_number,
+    block_timestamp,
+    tx_hash,
+    origin_function_signature,
+    origin_from_address,
+    origin_to_address,
+    contract_address,
+    pool_name,
+    event_name,
+    amount_in_unadj,
+    amount_out_unadj,
+    amount_in,
+    amount_out,
+    sender,
+    tx_to,
+    event_index,
+    platform,
+    token_in,
+    token_out,
+    symbol_in,
+    symbol_out,
+    decimals_in,
+    decimals_out,
+    _log_id,
+    _inserted_timestamp
+  FROM
+    trader_joe_v2_swaps
+  UNION ALL
+  SELECT
+    block_number,
+    block_timestamp,
+    tx_hash,
+    origin_function_signature,
+    origin_from_address,
+    origin_to_address,
+    contract_address,
+    pool_name,
+    event_name,
+    amount_in_unadj,
+    amount_out_unadj,
+    amount_in,
+    amount_out,
+    sender,
+    tx_to,
+    event_index,
+    platform,
+    token_in,
+    token_out,
+    symbol_in,
+    symbol_out,
+    decimals_in,
+    decimals_out,
+    _log_id,
+    _inserted_timestamp
+  FROM
+    woofi_swaps
+  UNION ALL
+  SELECT
+    block_number,
+    block_timestamp,
+    tx_hash,
+    origin_function_signature,
+    origin_from_address,
+    origin_to_address,
+    contract_address,
+    pool_name,
+    event_name,
+    amount_in_unadj,
+    amount_out_unadj,
+    amount_in,
+    amount_out,
+    sender,
+    tx_to,
+    event_index,
+    platform,
+    token_in,
+    token_out,
+    symbol_in,
+    symbol_out,
+    decimals_in,
+    decimals_out,
+    _log_id,
+    _inserted_timestamp
+  FROM
+    zyberswap_v2_swaps
+  UNION ALL
+  SELECT
+    block_number,
+    block_timestamp,
+    tx_hash,
+    origin_function_signature,
+    origin_from_address,
+    origin_to_address,
+    contract_address,
+    pool_name,
+    event_name,
+    amount_in_unadj,
+    amount_out_unadj,
+    amount_in,
+    amount_out,
+    sender,
+    tx_to,
+    event_index,
+    platform,
+    token_in,
+    token_out,
+    symbol_in,
+    symbol_out,
+    decimals_in,
+    decimals_out,
+    _log_id,
+    _inserted_timestamp
+  FROM
+    zyberswap_v3_swaps
+),
+--union all non-standard dex CTEs here (excludes amount_usd)
+all_dex_custom AS (
+  SELECT
+    block_number,
+    block_timestamp,
+    tx_hash,
+    origin_function_signature,
+    origin_from_address,
+    origin_to_address,
+    contract_address,
+    pool_name,
+    event_name,
+    amount_in_unadj,
+    amount_in,
+    amount_in_usd,
+    amount_out_unadj,
+    amount_out,
+    amount_out_usd,
+    sender,
+    tx_to,
+    event_index,
+    platform,
+    token_in,
+    token_out,
+    symbol_in,
+    symbol_out,
+    _log_id,
+    _inserted_timestamp
+  FROM
+    univ3_swaps
+),
+FINAL AS (
+  SELECT
+    block_number,
+    block_timestamp,
+    tx_hash,
+    origin_function_signature,
+    origin_from_address,
+    origin_to_address,
+    contract_address,
+    pool_name,
+    event_name,
+    amount_in_unadj,
+    amount_in,
+    CASE
+      WHEN s.decimals_in IS NOT NULL THEN ROUND(
+        amount_in * p1.price,
+        2
+      )
+      ELSE NULL
+    END AS amount_in_usd,
+    amount_out_unadj,
+    amount_out,
+    CASE
+      WHEN s.decimals_out IS NOT NULL THEN ROUND(
+        amount_out * p2.price,
+        2
+      )
+      ELSE NULL
+    END AS amount_out_usd,
+    sender,
+    tx_to,
+    event_index,
+    platform,
+    token_in,
+    token_out,
+    symbol_in,
+    symbol_out,
+    _log_id,
+    _inserted_timestamp
+  FROM
+    all_dex_standard s
+    LEFT JOIN prices p1
+    ON s.token_in = p1.token_address
+    AND DATE_TRUNC(
+      'hour',
+      block_timestamp
+    ) = p1.hour
+    LEFT JOIN prices p2
+    ON s.token_out = p2.token_address
+    AND DATE_TRUNC(
+      'hour',
+      block_timestamp
+    ) = p2.hour
+  UNION ALL
+  SELECT
+    block_number,
+    block_timestamp,
+    tx_hash,
+    origin_function_signature,
+    origin_from_address,
+    origin_to_address,
+    contract_address,
+    pool_name,
+    event_name,
+    amount_in_unadj,
+    amount_in,
+    ROUND(
+      amount_in_usd,
+      2
+    ) AS amount_in_usd,
+    amount_out_unadj,
+    amount_out,
+    ROUND(
+      amount_out_usd,
+      2
+    ) AS amount_out_usd,
+    sender,
+    tx_to,
+    event_index,
+    platform,
+    token_in,
+    token_out,
+    symbol_in,
+    symbol_out,
+    _log_id,
+    _inserted_timestamp
+  FROM
+    all_dex_custom C
+)
+SELECT
+  block_number,
+  block_timestamp,
+  tx_hash,
+  origin_function_signature,
+  origin_from_address,
+  origin_to_address,
+  contract_address,
+  pool_name,
+  event_name,
+  amount_in_unadj,
+  amount_in,
+  CASE
+    WHEN amount_out_usd IS NULL
+    OR ABS((amount_in_usd - amount_out_usd) / NULLIF(amount_out_usd, 0)) > 0.75
+    OR ABS((amount_in_usd - amount_out_usd) / NULLIF(amount_in_usd, 0)) > 0.75 THEN NULL
+    ELSE amount_in_usd
+  END AS amount_in_usd,
+  amount_out_unadj,
+  amount_out,
+  CASE
+    WHEN amount_in_usd IS NULL
+    OR ABS((amount_out_usd - amount_in_usd) / NULLIF(amount_in_usd, 0)) > 0.75
+    OR ABS((amount_out_usd - amount_in_usd) / NULLIF(amount_out_usd, 0)) > 0.75 THEN NULL
+    ELSE amount_out_usd
+  END AS amount_out_usd,
+  sender,
+  tx_to,
+  event_index,
+  platform,
+  token_in,
+  token_out,
+  symbol_in,
+  symbol_out,
+  _log_id,
+  _inserted_timestamp
+FROM
+  FINAL

--- a/models/silver/dex/silver_dex__complete_dex_swaps.yml
+++ b/models/silver/dex/silver_dex__complete_dex_swaps.yml
@@ -1,0 +1,130 @@
+version: 2
+models:
+  - name: silver_dex__complete_dex_swaps
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - _LOG_ID
+    columns:
+      - name: BLOCK_NUMBER
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - FLOAT
+      - name: BLOCK_TIMESTAMP
+        tests:
+          - not_null
+          - dbt_expectations.expect_row_values_to_have_recent_data:
+              datepart: day
+              interval: 1
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - TIMESTAMP_LTZ
+                - TIMESTAMP_NTZ
+      - name: TX_HASH
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: CONTRACT_ADDRESS
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: EVENT_NAME
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - STRING
+                - VARCHAR
+          - not_null
+      - name: AMOUNT_IN
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - FLOAT
+      - name: AMOUNT_OUT
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - FLOAT
+      - name: AMOUNT_IN_USD
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - FLOAT
+      - name: AMOUNT_OUT_USD
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - FLOAT
+      - name: TOKEN_IN
+        tests:
+          - not_null:
+              where: PLATFORM <> 'uniswap-v3'
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: TOKEN_OUT
+        tests:
+          - not_null:
+              where: PLATFORM <> 'uniswap-v3'
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: SYMBOL_IN
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - STRING
+                - VARCHAR
+      - name: SYMBOL_OUT
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - STRING
+                - VARCHAR
+      - name: SENDER
+        tests:
+          - not_null:
+              where: BLOCK_TIMESTAMP > '2021-08-01'
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: TX_TO
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+              enabled: False
+      - name: PLATFORM
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - STRING
+                - VARCHAR
+      - name: EVENT_INDEX
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - FLOAT
+      - name: _LOG_ID
+        tests:
+          - not_null
+      - name: ORIGIN_FUNCTION_SIGNATURE
+        tests:
+          - not_null
+      - name: ORIGIN_FROM_ADDRESS
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: ORIGIN_TO_ADDRESS
+        tests:
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+

--- a/models/silver/dex/sushi/silver_dex__sushi_pools.sql
+++ b/models/silver/dex/sushi/silver_dex__sushi_pools.sql
@@ -21,7 +21,7 @@ WITH pool_creation AS (
         _log_id,
         _inserted_timestamp
     FROM
-        {{ ref ('silver__logs2') }}
+        {{ ref ('silver__logs') }}
     WHERE
         contract_address = LOWER('0xc35DADB65012eC5796536bD9864eD8773aBc74C4')
         AND topics [0] :: STRING = '0x0d3648bd0f6ba80134a33ba9275ac585d9d315f0ad8355cddefde31afa28d0e9' --PairCreated

--- a/models/silver/dex/sushi/silver_dex__sushi_pools.sql
+++ b/models/silver/dex/sushi/silver_dex__sushi_pools.sql
@@ -1,0 +1,56 @@
+{{ config(
+    materialized = 'incremental',
+    unique_key = "pool_address"
+) }}
+
+WITH pool_creation AS (
+
+    SELECT
+        block_number,
+        block_timestamp,
+        tx_hash,
+        event_index,
+        contract_address,
+        regexp_substr_all(SUBSTR(DATA, 3, len(DATA)), '.{64}') AS segmented_data,
+        CONCAT('0x', SUBSTR(topics [1] :: STRING, 27, 40)) AS token0,
+        CONCAT('0x', SUBSTR(topics [2] :: STRING, 27, 40)) AS token1,
+        CONCAT('0x', SUBSTR(segmented_data [0] :: STRING, 25, 40)) AS pool_address,
+        utils.udf_hex_to_int(
+            segmented_data [1] :: STRING
+        ) :: INT AS pool_id,
+        _log_id,
+        _inserted_timestamp
+    FROM
+        {{ ref ('silver__logs2') }}
+    WHERE
+        contract_address = LOWER('0xc35DADB65012eC5796536bD9864eD8773aBc74C4')
+        AND topics [0] :: STRING = '0x0d3648bd0f6ba80134a33ba9275ac585d9d315f0ad8355cddefde31afa28d0e9' --PairCreated
+
+{% if is_incremental() %}
+AND _inserted_timestamp >= (
+    SELECT
+        MAX(_inserted_timestamp) :: DATE
+    FROM
+        {{ this }}
+)
+AND pool_address NOT IN (
+    SELECT
+        DISTINCT pool_address
+    FROM
+        {{ this }}
+)
+{% endif %}
+)
+SELECT
+    block_number,
+    block_timestamp,
+    tx_hash,
+    event_index,
+    token0,
+    token1,
+    pool_address,
+    pool_id,
+    _log_id,
+    _inserted_timestamp
+FROM
+    pool_creation

--- a/models/silver/dex/sushi/silver_dex__sushi_pools.yml
+++ b/models/silver/dex/sushi/silver_dex__sushi_pools.yml
@@ -1,0 +1,23 @@
+version: 2
+models:
+  - name: silver_dex__sushi_pools
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - POOL_ADDRESS
+    columns:
+      - name: POOL_ADDRESS
+        tests:
+          - not_null
+      - name: TOKEN0
+        tests:
+          - not_null
+      - name: TOKEN1
+        tests:
+          - not_null
+      - name: _INSERTED_TIMESTAMP
+        tests: 
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - TIMESTAMP_LTZ
+                - TIMESTAMP_NTZ

--- a/models/silver/dex/sushi/silver_dex__sushi_swaps.sql
+++ b/models/silver/dex/sushi/silver_dex__sushi_swaps.sql
@@ -1,0 +1,116 @@
+{{ config(
+    materialized = 'incremental',
+    unique_key = '_log_id',
+    cluster_by = ['block_timestamp::DATE']
+) }}
+
+WITH pools AS (
+
+    SELECT
+        pool_address,
+        token0,
+        token1
+    FROM
+        {{ ref('silver_dex__sushi_pools') }}
+),
+swaps_base AS (
+    SELECT
+        block_number,
+        origin_function_signature,
+        origin_from_address,
+        origin_to_address,
+        block_timestamp,
+        tx_hash,
+        event_index,
+        contract_address,
+        regexp_substr_all(SUBSTR(DATA, 3, len(DATA)), '.{64}') AS segmented_data,
+        TRY_TO_NUMBER(
+            utils.udf_hex_to_int(
+                segmented_data [0] :: STRING
+            ) :: INTEGER
+        ) AS amount0In,
+        TRY_TO_NUMBER(
+            utils.udf_hex_to_int(
+                segmented_data [1] :: STRING
+            ) :: INTEGER
+        ) AS amount1In,
+        TRY_TO_NUMBER(
+            utils.udf_hex_to_int(
+                segmented_data [2] :: STRING
+            ) :: INTEGER
+        ) AS amount0Out,
+        TRY_TO_NUMBER(
+            utils.udf_hex_to_int(
+                segmented_data [3] :: STRING
+            ) :: INTEGER
+        ) AS amount1Out,
+        CONCAT('0x', SUBSTR(topics [1] :: STRING, 27, 40)) AS sender,
+        CONCAT('0x', SUBSTR(topics [2] :: STRING, 27, 40)) AS tx_to,
+        token0,
+        token1,
+        _log_id,
+        _inserted_timestamp
+    FROM
+        {{ ref('silver__logs2') }}
+        INNER JOIN pools p
+        ON p.pool_address = contract_address
+    WHERE
+        topics [0] :: STRING = '0xd78ad95fa46c994b6551d0da85fc275fe613ce37657fb8d5e3d130840159d822'
+        AND tx_status = 'SUCCESS'
+
+{% if is_incremental() %}
+AND _inserted_timestamp >= (
+    SELECT
+        MAX(_inserted_timestamp) :: DATE
+    FROM
+        {{ this }}
+)
+{% endif %}
+)
+SELECT
+    block_number,
+    block_timestamp,
+    origin_function_signature,
+    origin_from_address,
+    origin_to_address,
+    tx_hash,
+    event_index,
+    contract_address,
+    sender,
+    tx_to,
+    amount0In,
+    amount1In,
+    amount0Out,
+    amount1Out,
+    token0,
+    token1,
+    CASE
+        WHEN amount0In <> 0
+        AND amount1In <> 0
+        AND amount0Out <> 0 THEN amount1In
+        WHEN amount0In <> 0 THEN amount0In
+        WHEN amount1In <> 0 THEN amount1In
+    END AS amount_in_unadj,
+    CASE
+        WHEN amount0Out <> 0 THEN amount0Out
+        WHEN amount1Out <> 0 THEN amount1Out
+    END AS amount_out_unadj,
+    CASE
+        WHEN amount0In <> 0
+        AND amount1In <> 0
+        AND amount0Out <> 0 THEN token1
+        WHEN amount0In <> 0 THEN token0
+        WHEN amount1In <> 0 THEN token1
+    END AS token_in,
+    CASE
+        WHEN amount0Out <> 0 THEN token0
+        WHEN amount1Out <> 0 THEN token1
+    END AS token_out,
+    'Swap' AS event_name,
+    'sushiswap' AS platform,
+    _log_id,
+    _inserted_timestamp
+FROM
+    swaps_base
+WHERE
+    token_in <> token_out

--- a/models/silver/dex/sushi/silver_dex__sushi_swaps.sql
+++ b/models/silver/dex/sushi/silver_dex__sushi_swaps.sql
@@ -51,7 +51,7 @@ swaps_base AS (
         _log_id,
         _inserted_timestamp
     FROM
-        {{ ref('silver__logs2') }}
+        {{ ref('silver__logs') }}
         INNER JOIN pools p
         ON p.pool_address = contract_address
     WHERE

--- a/models/silver/dex/sushi/silver_dex__sushi_swaps.yml
+++ b/models/silver/dex/sushi/silver_dex__sushi_swaps.yml
@@ -1,0 +1,116 @@
+version: 2
+models:
+  - name: silver_dex__sushi_swaps
+
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - _LOG_ID
+    columns:
+      - name: BLOCK_NUMBER
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - FLOAT
+      - name: BLOCK_TIMESTAMP
+        tests:
+          - not_null
+          - dbt_expectations.expect_row_values_to_have_recent_data:
+              datepart: day
+              interval: 2 #might be normal for swaps not to happen on a day
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - TIMESTAMP_LTZ
+                - TIMESTAMP_NTZ
+      - name: TX_HASH
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: CONTRACT_ADDRESS
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: AMOUNT_IN_UNADJ
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - FLOAT
+      - name: AMOUNT_IN
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - FLOAT
+      - name: AMOUNT_OUT_UNADJ
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - FLOAT
+      - name: AMOUNT_OUT
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - FLOAT
+      - name: TOKEN_IN
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+
+      - name: TOKEN_OUT
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: SYMBOL_IN
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - STRING
+                - VARCHAR
+      - name: SYMBOL_OUT
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - STRING
+                - VARCHAR
+      - name: TX_TO
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: PLATFORM
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - STRING
+                - VARCHAR
+      - name: EVENT_INDEX
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - FLOAT
+      - name: _LOG_ID
+        tests:
+          - not_null
+      - name: ORIGIN_FUNCTION_SIGNATURE
+        tests:
+          - not_null
+      - name: ORIGIN_FROM_ADDRESS
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: ORIGIN_TO_ADDRESS
+        tests:
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+

--- a/models/silver/dex/trader_joe/silver_dex__trader_joe_v1_pools.sql
+++ b/models/silver/dex/trader_joe/silver_dex__trader_joe_v1_pools.sql
@@ -21,7 +21,7 @@ WITH pool_creation AS (
         _log_id,
         _inserted_timestamp
     FROM
-        {{ ref ('silver__logs2') }}
+        {{ ref ('silver__logs') }}
     WHERE
         contract_address = LOWER('0xae4ec9901c3076d0ddbe76a520f9e90a6227acb7')
         AND topics [0] :: STRING = '0x0d3648bd0f6ba80134a33ba9275ac585d9d315f0ad8355cddefde31afa28d0e9' --PairCreated

--- a/models/silver/dex/trader_joe/silver_dex__trader_joe_v1_pools.sql
+++ b/models/silver/dex/trader_joe/silver_dex__trader_joe_v1_pools.sql
@@ -1,0 +1,56 @@
+{{ config(
+    materialized = 'incremental',
+    unique_key = "pool_address"
+) }}
+
+WITH pool_creation AS (
+
+    SELECT
+        block_number,
+        block_timestamp,
+        tx_hash,
+        event_index,
+        contract_address,
+        regexp_substr_all(SUBSTR(DATA, 3, len(DATA)), '.{64}') AS segmented_data,
+        CONCAT('0x', SUBSTR(topics [1] :: STRING, 27, 40)) AS token0,
+        CONCAT('0x', SUBSTR(topics [2] :: STRING, 27, 40)) AS token1,
+        CONCAT('0x', SUBSTR(segmented_data [0] :: STRING, 25, 40)) AS pool_address,
+        utils.udf_hex_to_int(
+            segmented_data [1] :: STRING
+        ) :: INT AS pool_id,
+        _log_id,
+        _inserted_timestamp
+    FROM
+        {{ ref ('silver__logs2') }}
+    WHERE
+        contract_address = LOWER('0xae4ec9901c3076d0ddbe76a520f9e90a6227acb7')
+        AND topics [0] :: STRING = '0x0d3648bd0f6ba80134a33ba9275ac585d9d315f0ad8355cddefde31afa28d0e9' --PairCreated
+
+{% if is_incremental() %}
+AND _inserted_timestamp >= (
+    SELECT
+        MAX(_inserted_timestamp) :: DATE
+    FROM
+        {{ this }}
+)
+AND pool_address NOT IN (
+    SELECT
+        DISTINCT pool_address
+    FROM
+        {{ this }}
+)
+{% endif %}
+)
+SELECT
+    block_number,
+    block_timestamp,
+    tx_hash,
+    event_index,
+    token0,
+    token1,
+    pool_address,
+    pool_id,
+    _log_id,
+    _inserted_timestamp
+FROM
+    pool_creation

--- a/models/silver/dex/trader_joe/silver_dex__trader_joe_v1_pools.yml
+++ b/models/silver/dex/trader_joe/silver_dex__trader_joe_v1_pools.yml
@@ -1,0 +1,23 @@
+version: 2
+models:
+  - name: silver_dex__trader_joe_v1_pools
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - POOL_ADDRESS
+    columns:
+      - name: POOL_ADDRESS
+        tests:
+          - not_null
+      - name: TOKEN0
+        tests:
+          - not_null
+      - name: TOKEN1
+        tests:
+          - not_null
+      - name: _INSERTED_TIMESTAMP
+        tests: 
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - TIMESTAMP_LTZ
+                - TIMESTAMP_NTZ

--- a/models/silver/dex/trader_joe/silver_dex__trader_joe_v1_swaps.sql
+++ b/models/silver/dex/trader_joe/silver_dex__trader_joe_v1_swaps.sql
@@ -51,7 +51,7 @@ swaps_base AS (
         l._log_id,
         l._inserted_timestamp
     FROM
-        {{ ref('silver__logs2') }}
+        {{ ref('silver__logs') }}
         l
         INNER JOIN pools p
         ON p.pool_address = l.contract_address

--- a/models/silver/dex/trader_joe/silver_dex__trader_joe_v1_swaps.sql
+++ b/models/silver/dex/trader_joe/silver_dex__trader_joe_v1_swaps.sql
@@ -1,0 +1,115 @@
+{{ config(
+    materialized = 'incremental',
+    unique_key = '_log_id',
+    cluster_by = ['block_timestamp::DATE']
+) }}
+
+WITH pools AS (
+
+    SELECT
+        pool_address,
+        token0,
+        token1
+    FROM
+        {{ ref('silver_dex__trader_joe_v1_pools') }}
+),
+swaps_base AS (
+    SELECT
+        l.block_number,
+        l.block_timestamp,
+        l.tx_hash,
+        origin_function_signature,
+        origin_from_address,
+        origin_to_address,
+        l.event_index,
+        l.contract_address,
+        regexp_substr_all(SUBSTR(l.data, 3, len(l.data)), '.{64}') AS l_segmented_data,
+        CONCAT('0x', SUBSTR(l.topics [1] :: STRING, 27, 40)) AS sender_address,
+        CONCAT('0x', SUBSTR(l.topics [2] :: STRING, 27, 40)) AS to_address,
+        TRY_TO_NUMBER(
+            utils.udf_hex_to_int(
+                l_segmented_data [0] :: STRING
+            )
+        ) AS amount0In,
+        TRY_TO_NUMBER(
+            utils.udf_hex_to_int(
+                l_segmented_data [1] :: STRING
+            )
+        ) AS amount1In,
+        TRY_TO_NUMBER(
+            utils.udf_hex_to_int(
+                l_segmented_data [2] :: STRING
+            )
+        ) AS amount0Out,
+        TRY_TO_NUMBER(
+            utils.udf_hex_to_int(
+                l_segmented_data [3] :: STRING
+            )
+        ) AS amount1Out,
+        token0,
+        token1,
+        l._log_id,
+        l._inserted_timestamp
+    FROM
+        {{ ref('silver__logs2') }}
+        l
+        INNER JOIN pools p
+        ON p.pool_address = l.contract_address
+    WHERE
+        l.topics [0] :: STRING = '0xd78ad95fa46c994b6551d0da85fc275fe613ce37657fb8d5e3d130840159d822' --Swap
+
+{% if is_incremental() %}
+AND _inserted_timestamp >= (
+    SELECT
+        MAX(_inserted_timestamp) :: DATE
+    FROM
+        {{ this }}
+)
+{% endif %}
+)
+SELECT
+    block_number,
+    block_timestamp,
+    tx_hash,
+    contract_address,
+    origin_function_signature,
+    origin_from_address,
+    origin_to_address,
+    event_index,
+    sender_address AS sender,
+    to_address AS tx_to,
+    amount0In,
+    amount1In,
+    amount0Out,
+    amount1Out,
+    token0,
+    token1,
+    CASE
+        WHEN amount0In <> 0
+            AND amount1In <> 0
+            AND amount0Out <> 0 THEN amount1In
+        WHEN amount0In <> 0 THEN amount0In
+        WHEN amount1In <> 0 THEN amount1In
+    END AS amount_in_unadj,
+    CASE
+        WHEN amount0Out <> 0 THEN amount0Out
+        WHEN amount1Out <> 0 THEN amount1Out
+    END AS amount_out_unadj,
+    CASE
+        WHEN amount0In <> 0
+            AND amount1In <> 0
+            AND amount0Out <> 0 THEN token1
+        WHEN amount0In <> 0 THEN token0
+        WHEN amount1In <> 0 THEN token1
+    END AS token_in,
+    CASE
+        WHEN amount0Out <> 0 THEN token0
+        WHEN amount1Out <> 0 THEN token1
+    END AS token_out,
+    'Swap' AS event_name,
+    'trader-joe-v1' AS platform,
+    _log_id,
+    _inserted_timestamp
+FROM
+    swaps_base
+WHERE token_in <> token_out

--- a/models/silver/dex/trader_joe/silver_dex__trader_joe_v1_swaps.yml
+++ b/models/silver/dex/trader_joe/silver_dex__trader_joe_v1_swaps.yml
@@ -1,0 +1,81 @@
+version: 2
+models:
+  - name: silver_dex__trader_joe_v1_swaps
+   
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - _LOG_ID
+    columns:
+      - name: BLOCK_NUMBER
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - FLOAT
+      - name: BLOCK_TIMESTAMP
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - TIMESTAMP_LTZ
+                - TIMESTAMP_NTZ
+      - name: TX_HASH
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: CONTRACT_ADDRESS
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: TOKEN_IN
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: TOKEN_OUT
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: SENDER
+        tests:
+          - not_null:
+              where: BLOCK_TIMESTAMP > '2021-08-01'
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: TX_TO
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: PLATFORM
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - STRING
+                - VARCHAR
+      - name: EVENT_INDEX
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - FLOAT
+      - name: _LOG_ID
+        tests:
+          - not_null
+      - name: ORIGIN_FUNCTION_SIGNATURE
+        tests:
+          - not_null
+      - name: ORIGIN_FROM_ADDRESS
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: ORIGIN_TO_ADDRESS
+        tests:
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+

--- a/models/silver/dex/trader_joe/silver_dex__trader_joe_v2_1_swaps.sql
+++ b/models/silver/dex/trader_joe/silver_dex__trader_joe_v2_1_swaps.sql
@@ -9,8 +9,7 @@ WITH pools AS (
     SELECT
         lb_pair,
         tokenX,
-        tokenY,
-        version
+        tokenY
     FROM
         {{ ref('silver_dex__trader_joe_v2_pools') }}
 ),
@@ -78,7 +77,6 @@ swaps_base AS (
         ON lb_pair = l.contract_address
     WHERE
         topics [0] :: STRING = '0xad7d6f97abf51ce18e17a38f4d70e975be9c0708474987bb3e26ad21bd93ca70' --Swap
-        AND version = 'v2.1'
 
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
@@ -114,8 +112,8 @@ SELECT
     tokenY,
     CASE
         WHEN amount0In <> 0
-            AND amount1In <> 0
-            AND amount0Out <> 0 THEN amount1In
+        AND amount1In <> 0
+        AND amount0Out <> 0 THEN amount1In
         WHEN amount0In <> 0 THEN amount0In
         WHEN amount1In <> 0 THEN amount1In
     END AS amount_in_unadj,
@@ -125,8 +123,8 @@ SELECT
     END AS amount_out_unadj,
     CASE
         WHEN amount0In <> 0
-            AND amount1In <> 0
-            AND amount0Out <> 0 THEN tokenX
+        AND amount1In <> 0
+        AND amount0Out <> 0 THEN tokenX
         WHEN amount0In <> 0 THEN tokenY
         WHEN amount1In <> 0 THEN tokenX
     END AS token_in,
@@ -140,4 +138,5 @@ SELECT
     _inserted_timestamp
 FROM
     swaps_base
-WHERE token_in <> token_out
+WHERE
+    token_in <> token_out

--- a/models/silver/dex/trader_joe/silver_dex__trader_joe_v2_1_swaps.sql
+++ b/models/silver/dex/trader_joe/silver_dex__trader_joe_v2_1_swaps.sql
@@ -72,7 +72,7 @@ swaps_base AS (
         l._log_id,
         l._inserted_timestamp
     FROM
-        {{ ref('silver__logs2') }}
+        {{ ref('silver__logs') }}
         l
         INNER JOIN pools p
         ON lb_pair = l.contract_address

--- a/models/silver/dex/trader_joe/silver_dex__trader_joe_v2_1_swaps.sql
+++ b/models/silver/dex/trader_joe/silver_dex__trader_joe_v2_1_swaps.sql
@@ -1,0 +1,143 @@
+{{ config(
+    materialized = 'incremental',
+    unique_key = '_log_id',
+    cluster_by = ['block_timestamp::DATE']
+) }}
+
+WITH pools AS (
+
+    SELECT
+        lb_pair,
+        tokenX,
+        tokenY,
+        version
+    FROM
+        {{ ref('silver_dex__trader_joe_v2_pools') }}
+),
+swaps_base AS (
+    SELECT
+        l.block_number,
+        l.block_timestamp,
+        l.origin_function_signature,
+        l.origin_from_address,
+        l.origin_to_address,
+        l.tx_hash,
+        l.event_index,
+        l.contract_address,
+        l.topics,
+        l.data,
+        regexp_substr_all(SUBSTR(DATA, 3, len(DATA)), '.{64}') AS l_segmented_data,
+        CONCAT('0x', SUBSTR(l.topics [1] :: STRING, 27, 40)) AS sender_address,
+        CONCAT('0x', SUBSTR(l.topics [2] :: STRING, 27, 40)) AS to_address,
+        TRY_TO_NUMBER(
+            utils.udf_hex_to_int(
+                l_segmented_data [0] :: STRING
+            )
+        ) AS id,
+        l_segmented_data [1] :: STRING AS amountsIn,
+        TRY_TO_NUMBER(
+            utils.udf_hex_to_int(SUBSTR(amountsIn, 0, 32))
+        ) AS amount0In,
+        TRY_TO_NUMBER(
+            utils.udf_hex_to_int(SUBSTR(amountsIn, 33, 32))
+        ) AS amount1In,
+        l_segmented_data [2] :: STRING AS amountsOut,
+        TRY_TO_NUMBER(
+            utils.udf_hex_to_int(SUBSTR(amountsOut, 0, 32))
+        ) AS amount0Out,
+        TRY_TO_NUMBER(
+            utils.udf_hex_to_int(SUBSTR(amountsOut, 33, 32))
+        ) AS amount1Out,
+        TRY_TO_NUMBER(
+            utils.udf_hex_to_int(
+                l_segmented_data [3] :: STRING
+            )
+        ) AS volatilityAccumulated,
+        l_segmented_data [4] :: STRING AS totalFees,
+        TRY_TO_NUMBER(
+            utils.udf_hex_to_int(SUBSTR(totalFees, 0, 32))
+        ) AS fee0,
+        TRY_TO_NUMBER(
+            utils.udf_hex_to_int(SUBSTR(totalFees, 33, 32))
+        ) AS fee1,
+        l_segmented_data [5] :: STRING AS protocolFees,
+        TRY_TO_NUMBER(
+            utils.udf_hex_to_int(SUBSTR(protocolFees, 0, 32))
+        ) AS protocolFee0,
+        TRY_TO_NUMBER(
+            utils.udf_hex_to_int(SUBSTR(protocolFees, 33, 32))
+        ) AS protocolFee1,
+        tokenX,
+        tokenY,
+        l._log_id,
+        l._inserted_timestamp
+    FROM
+        {{ ref('silver__logs2') }}
+        l
+        INNER JOIN pools p
+        ON lb_pair = l.contract_address
+    WHERE
+        topics [0] :: STRING = '0xad7d6f97abf51ce18e17a38f4d70e975be9c0708474987bb3e26ad21bd93ca70' --Swap
+        AND version = 'v2.1'
+
+{% if is_incremental() %}
+AND _inserted_timestamp >= (
+    SELECT
+        MAX(_inserted_timestamp) :: DATE
+    FROM
+        {{ this }}
+)
+{% endif %}
+)
+SELECT
+    block_number,
+    block_timestamp,
+    tx_hash,
+    origin_function_signature,
+    origin_from_address,
+    origin_to_address,
+    event_index,
+    contract_address,
+    sender_address AS sender,
+    to_address AS tx_to,
+    id,
+    amount0In,
+    amount1In,
+    amount0Out,
+    amount1Out,
+    volatilityAccumulated AS volatility_accumulated,
+    fee0,
+    fee1,
+    protocolFee0 AS protocol_fee0,
+    protocolFee1 AS protocol_fee1,
+    tokenX,
+    tokenY,
+    CASE
+        WHEN amount0In <> 0
+            AND amount1In <> 0
+            AND amount0Out <> 0 THEN amount1In
+        WHEN amount0In <> 0 THEN amount0In
+        WHEN amount1In <> 0 THEN amount1In
+    END AS amount_in_unadj,
+    CASE
+        WHEN amount0Out <> 0 THEN amount0Out
+        WHEN amount1Out <> 0 THEN amount1Out
+    END AS amount_out_unadj,
+    CASE
+        WHEN amount0In <> 0
+            AND amount1In <> 0
+            AND amount0Out <> 0 THEN tokenX
+        WHEN amount0In <> 0 THEN tokenY
+        WHEN amount1In <> 0 THEN tokenX
+    END AS token_in,
+    CASE
+        WHEN amount0Out <> 0 THEN tokenY
+        WHEN amount1Out <> 0 THEN tokenX
+    END AS token_out,
+    'Swap' AS event_name,
+    'trader-joe-v2' AS platform,
+    _log_id,
+    _inserted_timestamp
+FROM
+    swaps_base
+WHERE token_in <> token_out

--- a/models/silver/dex/trader_joe/silver_dex__trader_joe_v2_1_swaps.yml
+++ b/models/silver/dex/trader_joe/silver_dex__trader_joe_v2_1_swaps.yml
@@ -1,0 +1,81 @@
+version: 2
+models:
+  - name: silver_dex__trader_joe_v2_1_swaps
+   
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - _LOG_ID
+    columns:
+      - name: BLOCK_NUMBER
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - FLOAT
+      - name: BLOCK_TIMESTAMP
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - TIMESTAMP_LTZ
+                - TIMESTAMP_NTZ
+      - name: TX_HASH
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: CONTRACT_ADDRESS
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: TOKEN_IN
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: TOKEN_OUT
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: SENDER
+        tests:
+          - not_null:
+              where: BLOCK_TIMESTAMP > '2021-08-01'
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: TX_TO
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: PLATFORM
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - STRING
+                - VARCHAR
+      - name: EVENT_INDEX
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - FLOAT
+      - name: _LOG_ID
+        tests:
+          - not_null
+      - name: ORIGIN_FUNCTION_SIGNATURE
+        tests:
+          - not_null
+      - name: ORIGIN_FROM_ADDRESS
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: ORIGIN_TO_ADDRESS
+        tests:
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+

--- a/models/silver/dex/trader_joe/silver_dex__trader_joe_v2_pools.sql
+++ b/models/silver/dex/trader_joe/silver_dex__trader_joe_v2_pools.sql
@@ -21,16 +21,17 @@ WITH pool_creation AS (
         utils.udf_hex_to_int(
             segmented_data [1] :: STRING
         ) :: INT AS pool_id,
-        CASE
-            WHEN contract_address = '0x1886d09c9ade0c5db822d85d21678db67b6c2982' THEN 'v2'
-            WHEN contract_address = '0x8e42f2f4101563bf679975178e880fd87d3efd4e' THEN 'v2.1'
-        END AS version,
         _log_id,
         _inserted_timestamp
-    FROM 
+    FROM
         {{ ref('silver__logs') }}
     WHERE
-        contract_address IN ('0x1886d09c9ade0c5db822d85d21678db67b6c2982','0x8e42f2f4101563bf679975178e880fd87d3efd4e')
+        contract_address IN (
+            '0x1886d09c9ade0c5db822d85d21678db67b6c2982',
+            '0x8e42f2f4101563bf679975178e880fd87d3efd4e',
+            '0xee0616a2deaa5331e2047bc61e0b588195a49cea',
+            '0x8597db3ba8de6baadeda8cba4dac653e24a0e57b'
+        )
         AND topics [0] :: STRING = '0x2c8d104b27c6b7f4492017a6f5cf3803043688934ebcaa6a03540beeaf976aff' --LB PairCreated
 
 {% if is_incremental() %}
@@ -58,7 +59,6 @@ SELECT
     binStep AS bin_step,
     lb_pair,
     pool_id,
-    version,
     _log_id,
     _inserted_timestamp
 FROM

--- a/models/silver/dex/trader_joe/silver_dex__trader_joe_v2_pools.sql
+++ b/models/silver/dex/trader_joe/silver_dex__trader_joe_v2_pools.sql
@@ -1,0 +1,65 @@
+{{ config(
+    materialized = 'incremental',
+    unique_key = "lb_pair"
+) }}
+
+WITH pool_creation AS (
+
+    SELECT
+        block_number,
+        block_timestamp,
+        tx_hash,
+        event_index,
+        contract_address,
+        regexp_substr_all(SUBSTR(DATA, 3, len(DATA)), '.{64}') AS segmented_data,
+        CONCAT('0x', SUBSTR(topics [1] :: STRING, 27, 40)) AS tokenX,
+        CONCAT('0x', SUBSTR(topics [2] :: STRING, 27, 40)) AS tokenY,
+        utils.udf_hex_to_int(
+            topics [3] :: STRING
+        ) :: INT AS binStep,
+        CONCAT('0x', SUBSTR(segmented_data [0] :: STRING, 25, 40)) AS lb_pair,
+        utils.udf_hex_to_int(
+            segmented_data [1] :: STRING
+        ) :: INT AS pool_id,
+        CASE
+            WHEN contract_address = '0x1886d09c9ade0c5db822d85d21678db67b6c2982' THEN 'v2'
+            WHEN contract_address = '0x8e42f2f4101563bf679975178e880fd87d3efd4e' THEN 'v2.1'
+        END AS version,
+        _log_id,
+        _inserted_timestamp
+    FROM 
+        {{ ref('silver__logs2') }}
+    WHERE
+        contract_address IN ('0x1886d09c9ade0c5db822d85d21678db67b6c2982','0x8e42f2f4101563bf679975178e880fd87d3efd4e')
+        AND topics [0] :: STRING = '0x2c8d104b27c6b7f4492017a6f5cf3803043688934ebcaa6a03540beeaf976aff' --LB PairCreated
+
+{% if is_incremental() %}
+AND _inserted_timestamp >= (
+    SELECT
+        MAX(_inserted_timestamp) :: DATE
+    FROM
+        {{ this }}
+)
+AND lb_pair NOT IN (
+    SELECT
+        DISTINCT lb_pair
+    FROM
+        {{ this }}
+)
+{% endif %}
+)
+SELECT
+    block_number,
+    block_timestamp,
+    tx_hash,
+    event_index,
+    tokenX,
+    tokenY,
+    binStep AS bin_step,
+    lb_pair,
+    pool_id,
+    version,
+    _log_id,
+    _inserted_timestamp
+FROM
+    pool_creation

--- a/models/silver/dex/trader_joe/silver_dex__trader_joe_v2_pools.sql
+++ b/models/silver/dex/trader_joe/silver_dex__trader_joe_v2_pools.sql
@@ -28,7 +28,7 @@ WITH pool_creation AS (
         _log_id,
         _inserted_timestamp
     FROM 
-        {{ ref('silver__logs2') }}
+        {{ ref('silver__logs') }}
     WHERE
         contract_address IN ('0x1886d09c9ade0c5db822d85d21678db67b6c2982','0x8e42f2f4101563bf679975178e880fd87d3efd4e')
         AND topics [0] :: STRING = '0x2c8d104b27c6b7f4492017a6f5cf3803043688934ebcaa6a03540beeaf976aff' --LB PairCreated

--- a/models/silver/dex/trader_joe/silver_dex__trader_joe_v2_pools.yml
+++ b/models/silver/dex/trader_joe/silver_dex__trader_joe_v2_pools.yml
@@ -1,0 +1,23 @@
+version: 2
+models:
+  - name: silver_dex__trader_joe_v2_pools
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - LB_PAIR
+    columns:
+      - name: LB_PAIR
+        tests:
+          - not_null
+      - name: TOKENX
+        tests:
+          - not_null
+      - name: TOKENY
+        tests:
+          - not_null
+      - name: _INSERTED_TIMESTAMP
+        tests: 
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - TIMESTAMP_LTZ
+                - TIMESTAMP_NTZ

--- a/models/silver/dex/trader_joe/silver_dex__trader_joe_v2_swaps.sql
+++ b/models/silver/dex/trader_joe/silver_dex__trader_joe_v2_swaps.sql
@@ -9,8 +9,7 @@ WITH pools AS (
     SELECT
         lb_pair,
         tokenX,
-        tokenY,
-        version
+        tokenY
     FROM
         {{ ref('silver_dex__trader_joe_v2_pools') }}
 ),
@@ -77,7 +76,6 @@ swaps_base AS (
         ON lb_pair = l.contract_address
     WHERE
         topics [0] :: STRING = '0xc528cda9e500228b16ce84fadae290d9a49aecb17483110004c5af0a07f6fd73' --Swap
-        AND version = 'v2'
 
 {% if is_incremental() %}
 AND _inserted_timestamp >= (

--- a/models/silver/dex/trader_joe/silver_dex__trader_joe_v2_swaps.sql
+++ b/models/silver/dex/trader_joe/silver_dex__trader_joe_v2_swaps.sql
@@ -71,7 +71,7 @@ swaps_base AS (
         l._log_id,
         l._inserted_timestamp
     FROM
-        {{ ref('silver__logs2') }}
+        {{ ref('silver__logs') }}
         l
         INNER JOIN pools p
         ON lb_pair = l.contract_address

--- a/models/silver/dex/trader_joe/silver_dex__trader_joe_v2_swaps.sql
+++ b/models/silver/dex/trader_joe/silver_dex__trader_joe_v2_swaps.sql
@@ -1,0 +1,115 @@
+{{ config(
+    materialized = 'incremental',
+    unique_key = '_log_id',
+    cluster_by = ['block_timestamp::DATE']
+) }}
+
+WITH pools AS (
+
+    SELECT
+        lb_pair,
+        tokenX,
+        tokenY,
+        version
+    FROM
+        {{ ref('silver_dex__trader_joe_v2_pools') }}
+),
+swaps_base AS (
+    SELECT
+        l.block_number,
+        l.block_timestamp,
+        l.tx_hash,
+        l.origin_function_signature,
+        l.origin_from_address,
+        l.origin_to_address,
+        l.event_index,
+        l.contract_address,
+        l.topics,
+        l.data,
+        regexp_substr_all(SUBSTR(DATA, 3, len(DATA)), '.{64}') AS l_segmented_data,
+        CONCAT('0x', SUBSTR(l.topics [1] :: STRING, 27, 40)) AS sender_address,
+        CONCAT('0x', SUBSTR(l.topics [2] :: STRING, 27, 40)) AS recipient_address,
+        TRY_TO_NUMBER(
+            utils.udf_hex_to_int(
+                l.topics [3] :: STRING
+            )
+        ) AS id,
+        CASE
+            WHEN utils.udf_hex_to_int(
+                l_segmented_data [0] :: STRING
+            ) = 0 THEN FALSE
+            ELSE TRUE
+        END AS swapForY,
+        TRY_TO_NUMBER(
+            utils.udf_hex_to_int(
+                l_segmented_data [1] :: STRING
+            )
+        ) AS amountIn,
+        TRY_TO_NUMBER(
+            utils.udf_hex_to_int(
+                l_segmented_data [2] :: STRING
+            )
+        ) AS amountOut,
+        TRY_TO_NUMBER(
+            utils.udf_hex_to_int(
+                l_segmented_data [3] :: STRING
+            )
+        ) AS volatilityAccumulated,
+        TRY_TO_NUMBER(
+            utils.udf_hex_to_int(
+                l_segmented_data [4] :: STRING
+            )
+        ) AS fees,
+        CASE
+            WHEN swapForY THEN tokenY
+            ELSE tokenX
+        END AS token_out_address,
+        CASE
+            WHEN swapForY THEN tokenX
+            ELSE tokenY
+        END AS token_in_address,
+        l._log_id,
+        l._inserted_timestamp
+    FROM
+        {{ ref('silver__logs2') }}
+        l
+        INNER JOIN pools p
+        ON lb_pair = l.contract_address
+    WHERE
+        topics [0] :: STRING = '0xc528cda9e500228b16ce84fadae290d9a49aecb17483110004c5af0a07f6fd73' --Swap
+        AND version = 'v2'
+
+{% if is_incremental() %}
+AND _inserted_timestamp >= (
+    SELECT
+        MAX(_inserted_timestamp) :: DATE
+    FROM
+        {{ this }}
+)
+{% endif %}
+)
+SELECT
+    block_number,
+    block_timestamp,
+    tx_hash,
+    origin_function_signature,
+    origin_from_address,
+    origin_to_address,
+    event_index,
+    contract_address,
+    sender_address AS sender,
+    recipient_address AS tx_to,
+    id,
+    swapForY AS swap_for_y,
+    amountIn AS amount_in_unadj,
+    amountOut AS amount_out_unadj,
+    volatilityAccumulated AS volatility_accumulated,
+    fees,
+    token_in_address AS token_in,
+    token_out_address AS token_out,
+    'Swap' AS event_name,
+    'trader-joe-v2' AS platform,
+    _log_id,
+    _inserted_timestamp
+FROM
+    swaps_base

--- a/models/silver/dex/trader_joe/silver_dex__trader_joe_v2_swaps.yml
+++ b/models/silver/dex/trader_joe/silver_dex__trader_joe_v2_swaps.yml
@@ -1,0 +1,81 @@
+version: 2
+models:
+  - name: silver_dex__trader_joe_v2_swaps
+   
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - _LOG_ID
+    columns:
+      - name: BLOCK_NUMBER
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - FLOAT
+      - name: BLOCK_TIMESTAMP
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - TIMESTAMP_LTZ
+                - TIMESTAMP_NTZ
+      - name: TX_HASH
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: CONTRACT_ADDRESS
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: TOKEN_IN
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: TOKEN_OUT
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: SENDER
+        tests:
+          - not_null:
+              where: BLOCK_TIMESTAMP > '2021-08-01'
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: TX_TO
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: PLATFORM
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - STRING
+                - VARCHAR
+      - name: EVENT_INDEX
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - FLOAT
+      - name: _LOG_ID
+        tests:
+          - not_null
+      - name: ORIGIN_FUNCTION_SIGNATURE
+        tests:
+          - not_null
+      - name: ORIGIN_FROM_ADDRESS
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: ORIGIN_TO_ADDRESS
+        tests:
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+

--- a/models/silver/dex/uniswap/silver_dex__univ3_pools.sql
+++ b/models/silver/dex/uniswap/silver_dex__univ3_pools.sql
@@ -24,7 +24,7 @@ WITH created_pools AS (
         CONCAT('0x', SUBSTR(segmented_data [1] :: STRING, 25, 40)) AS pool_address,
         _inserted_timestamp
     FROM
-        {{ ref('silver__logs2') }}
+        {{ ref('silver__logs') }}
     WHERE
         topics [0] = '0x783cca1c0412dd0d695e784568c96da2e9c22ff989357a2e8b1d9b2b4e6b7118'
         AND contract_address = '0x1f98431c8ad98523631ae4a59f267346ea31f984'
@@ -51,7 +51,7 @@ initial_info AS (
             init_tick
         ) AS init_price_1_0_unadj
     FROM
-        {{ ref('silver__logs2') }}
+        {{ ref('silver__logs') }}
     WHERE
         topics [0] :: STRING = '0x98636036cb66a9c19a37435efc1e90142190214e8abeb821bdba3f2990dd4c95'
 

--- a/models/silver/dex/uniswap/silver_dex__univ3_pools.sql
+++ b/models/silver/dex/uniswap/silver_dex__univ3_pools.sql
@@ -1,0 +1,99 @@
+{{ config(
+    materialized = 'incremental',
+    unique_key = 'pool_address',
+    cluster_by = ['_inserted_timestamp::DATE']
+) }}
+
+WITH created_pools AS (
+
+    SELECT
+        block_number AS created_block,
+        block_timestamp AS created_time,
+        tx_hash AS created_tx_hash,
+        regexp_substr_all(SUBSTR(DATA, 3, len(DATA)), '.{64}') AS segmented_data,
+        LOWER(CONCAT('0x', SUBSTR(topics [1] :: STRING, 27, 40))) AS token0_address,
+        LOWER(CONCAT('0x', SUBSTR(topics [2] :: STRING, 27, 40))) AS token1_address,
+        utils.udf_hex_to_int(
+            's2c',
+            topics [3] :: STRING
+        ) :: INTEGER AS fee,
+        utils.udf_hex_to_int(
+            's2c',
+            segmented_data [0] :: STRING
+        ) :: INTEGER AS tick_spacing,
+        CONCAT('0x', SUBSTR(segmented_data [1] :: STRING, 25, 40)) AS pool_address,
+        _inserted_timestamp
+    FROM
+        {{ ref('silver__logs2') }}
+    WHERE
+        topics [0] = '0x783cca1c0412dd0d695e784568c96da2e9c22ff989357a2e8b1d9b2b4e6b7118'
+        AND contract_address = '0x1f98431c8ad98523631ae4a59f267346ea31f984'
+
+{% if is_incremental() %}
+AND _inserted_timestamp >= (
+    SELECT
+        MAX(
+            _inserted_timestamp
+        ) :: DATE
+    FROM
+        {{ this }}
+)
+{% endif %}
+),
+initial_info AS (
+    SELECT
+        contract_address,
+        regexp_substr_all(SUBSTR(DATA, 3, len(DATA)), '.{64}') AS segmented_data,
+        utils.udf_hex_to_int('s2c', CONCAT('0x', segmented_data [0] :: STRING)) :: FLOAT AS init_sqrtPriceX96,
+        utils.udf_hex_to_int('s2c', CONCAT('0x', segmented_data [1] :: STRING)) :: FLOAT AS init_tick,
+        pow(
+            1.0001,
+            init_tick
+        ) AS init_price_1_0_unadj
+    FROM
+        {{ ref('silver__logs2') }}
+    WHERE
+        topics [0] :: STRING = '0x98636036cb66a9c19a37435efc1e90142190214e8abeb821bdba3f2990dd4c95'
+
+{% if is_incremental() %}
+AND _inserted_timestamp >= (
+    SELECT
+        MAX(
+            _inserted_timestamp
+        ) :: DATE - 2
+    FROM
+        {{ this }}
+)
+{% endif %}
+),
+
+FINAL AS (
+    SELECT
+        created_block,
+        created_time,
+        created_tx_hash,
+        token0_address,
+        token1_address,
+        fee :: INTEGER AS fee,
+        (
+            fee / 10000
+        ) :: FLOAT AS fee_percent,
+        tick_spacing,
+        pool_address,
+        COALESCE(
+            init_tick,
+            0
+        ) AS init_tick,
+        _inserted_timestamp
+    FROM
+        created_pools
+        LEFT JOIN initial_info
+        ON pool_address = contract_address
+)
+
+SELECT
+    *
+FROM
+    FINAL qualify(ROW_NUMBER() over(PARTITION BY pool_address
+ORDER BY
+    _inserted_timestamp DESC)) = 1

--- a/models/silver/dex/uniswap/silver_dex__univ3_pools.yml
+++ b/models/silver/dex/uniswap/silver_dex__univ3_pools.yml
@@ -1,0 +1,40 @@
+version: 2
+models:
+  - name: silver_dex__univ3_pools
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - POOL_ADDRESS
+    columns:
+      - name: CREATED_BLOCK
+        tests:
+          - not_null
+      - name: CREATED_TIME
+        tests:
+          - not_null
+          - dbt_expectations.expect_row_values_to_have_recent_data:
+              datepart: day
+              interval: 7
+      - name: FEE
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - decimal
+                - float
+                - number
+      - name: INIT_TICK
+        tests:
+          - not_null
+      - name: POOL_ADDRESS
+        tests:
+          - not_null
+      - name: TICK_SPACING
+        tests:
+          - not_null
+      - name: CREATED_TX_HASH
+        tests:
+          - not_null
+
+
+

--- a/models/silver/dex/uniswap/silver_dex__univ3_swaps.sql
+++ b/models/silver/dex/uniswap/silver_dex__univ3_swaps.sql
@@ -32,7 +32,7 @@ WITH base_swaps AS (
             segmented_data [4] :: STRING
         ) :: FLOAT AS tick
     FROM
-        {{ ref('silver__logs2') }}
+        {{ ref('silver__logs') }}
     WHERE
         block_timestamp :: DATE > '2021-04-01'
         AND topics [0] :: STRING = '0xc42079f94a6350d7e6235f29174924f928cc2ac818eb64fed8004e115fbcca67'

--- a/models/silver/dex/uniswap/silver_dex__univ3_swaps.sql
+++ b/models/silver/dex/uniswap/silver_dex__univ3_swaps.sql
@@ -1,0 +1,96 @@
+{{ config(
+    materialized = 'incremental',
+    unique_key = '_log_id',
+    cluster_by = ['block_timestamp::DATE']
+) }}
+
+WITH base_swaps AS (
+
+    SELECT
+        *,
+        regexp_substr_all(SUBSTR(DATA, 3, len(DATA)), '.{64}') AS segmented_data,
+        CONCAT('0x', SUBSTR(topics [1] :: STRING, 27, 40)) AS sender,
+        CONCAT('0x', SUBSTR(topics [2] :: STRING, 27, 40)) AS recipient,
+        utils.udf_hex_to_int(
+            's2c',
+            segmented_data [0] :: STRING
+        ) :: FLOAT AS amount0_unadj,
+        utils.udf_hex_to_int(
+            's2c',
+            segmented_data [1] :: STRING
+        ) :: FLOAT AS amount1_unadj,
+        utils.udf_hex_to_int(
+            's2c',
+            segmented_data [2] :: STRING
+        ) :: FLOAT AS sqrtPriceX96,
+        utils.udf_hex_to_int(
+            's2c',
+            segmented_data [3] :: STRING
+        ) :: FLOAT AS liquidity,
+        utils.udf_hex_to_int(
+            's2c',
+            segmented_data [4] :: STRING
+        ) :: FLOAT AS tick
+    FROM
+        {{ ref('silver__logs2') }}
+    WHERE
+        block_timestamp :: DATE > '2021-04-01'
+        AND topics [0] :: STRING = '0xc42079f94a6350d7e6235f29174924f928cc2ac818eb64fed8004e115fbcca67'
+        AND tx_status = 'SUCCESS'
+        AND event_removed = 'false'
+
+{% if is_incremental() %}
+AND _inserted_timestamp >= (
+    SELECT
+        MAX(
+            _inserted_timestamp
+        ) :: DATE
+    FROM
+        {{ this }}
+)
+{% endif %}
+),
+pool_data AS (
+    SELECT
+        token0_address,
+        token1_address,
+        fee,
+        fee_percent,
+        tick_spacing,
+        pool_address
+    FROM
+        {{ ref('silver_dex__univ3_pools') }}
+),
+FINAL AS (
+    SELECT
+        block_number,
+        block_timestamp,
+        tx_hash,
+        contract_address AS pool_address,
+        recipient,
+        sender,
+        fee,
+        tick,
+        tick_spacing,
+        liquidity,
+        event_index,
+        token0_address,
+        token1_address,
+        _log_id,
+        _inserted_timestamp,
+        origin_function_signature,
+        origin_from_address,
+        origin_to_address,
+        amount0_unadj,
+        amount1_unadj
+    FROM
+        base_swaps
+        INNER JOIN pool_data
+        ON pool_data.pool_address = base_swaps.contract_address
+)
+SELECT
+    *
+FROM
+    FINAL qualify(ROW_NUMBER() over(PARTITION BY _log_id
+ORDER BY
+    _inserted_timestamp DESC)) = 1

--- a/models/silver/dex/uniswap/silver_dex__univ3_swaps.yml
+++ b/models/silver/dex/uniswap/silver_dex__univ3_swaps.yml
@@ -1,0 +1,56 @@
+version: 2
+models:
+  - name: silver_dex__univ3_swaps
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - _LOG_ID
+    columns:
+      - name: AMOUNT0_UNADJ
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - decimal
+                - float
+      - name: AMOUNT1_UNADJ
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - decimal
+                - float
+      - name: BLOCK_NUMBER
+        tests:
+          - not_null
+      - name: BLOCK_TIMESTAMP
+        tests:
+          - not_null
+          - dbt_expectations.expect_row_values_to_have_recent_data:
+              datepart: day
+              interval: 1
+      - name: LIQUIDITY
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - decimal
+                - float
+      - name: EVENT_INDEX
+        tests:
+          - not_null
+      - name: POOL_ADDRESS
+        tests:
+          - not_null
+      - name: RECIPIENT
+        tests:
+          - not_null
+      - name: SENDER
+        tests:
+          - not_null
+      - name: TICK
+        tests:
+          - not_null
+      - name: TX_HASH
+        tests:
+          - not_null

--- a/models/silver/dex/woofi/silver_dex__woofi_swaps.sql
+++ b/models/silver/dex/woofi/silver_dex__woofi_swaps.sql
@@ -53,7 +53,7 @@ WITH router_swaps_base AS (
         l._log_id,
         l._inserted_timestamp
     FROM
-        {{ ref('silver__logs2') }}
+        {{ ref('silver__logs') }}
         l
     WHERE
         contract_address IN (
@@ -117,7 +117,7 @@ swaps_base AS (
         l._log_id,
         l._inserted_timestamp
     FROM
-        {{ ref('silver__logs2') }}
+        {{ ref('silver__logs') }}
         l
     WHERE
         contract_address IN (

--- a/models/silver/dex/woofi/silver_dex__woofi_swaps.sql
+++ b/models/silver/dex/woofi/silver_dex__woofi_swaps.sql
@@ -1,0 +1,210 @@
+{{ config(
+    materialized = 'incremental',
+    unique_key = '_log_id',
+    cluster_by = ['block_timestamp::DATE']
+) }}
+
+WITH router_swaps_base AS (
+
+    SELECT
+        l.block_number,
+        l.block_timestamp,
+        l.tx_hash,
+        origin_function_signature,
+        origin_from_address,
+        origin_to_address,
+        l.event_index,
+        l.contract_address,
+        regexp_substr_all(SUBSTR(l.data, 3, len(l.data)), '.{64}') AS l_segmented_data,
+        CONCAT('0x', SUBSTR(l.topics [1] :: STRING, 27, 40)) AS from_token,
+        CONCAT('0x', SUBSTR(l.topics [2] :: STRING, 27, 40)) AS to_token,
+        CONCAT('0x', SUBSTR(l.topics [3] :: STRING, 27, 40)) AS to_address,
+        TRY_TO_NUMBER(
+            utils.udf_hex_to_int(
+                l_segmented_data [0] :: STRING
+            )
+        ) AS swapType,
+        TRY_TO_NUMBER(
+            utils.udf_hex_to_int(
+                l_segmented_data [1] :: STRING
+            )
+        ) AS fromAmount,
+        TRY_TO_NUMBER(
+            utils.udf_hex_to_int(
+                l_segmented_data [2] :: STRING
+            )
+        ) AS toAmount,
+        CONCAT(
+            '0x',
+            SUBSTR(
+                l_segmented_data [3] :: STRING,
+                25,
+                40
+            )
+        ) AS from_address,
+        CONCAT(
+            '0x',
+            SUBSTR(
+                l_segmented_data [4] :: STRING,
+                25,
+                40
+            )
+        ) AS rebateTo,
+        l._log_id,
+        l._inserted_timestamp
+    FROM
+        {{ ref('silver__logs2') }}
+        l
+    WHERE
+        contract_address IN (
+            '0xcdfd61a8303beb5c8dd2a6d02df8d228ce15b9f3',
+            '0x9aed3a8896a85fe9a8cac52c9b402d092b629a30',
+            '0xd2635bc7e4e4f63b2892ed80d0b0f9dff7eda899',
+            --v2
+            '0xb130a49065178465931d4f887056328cea5d723f'
+        ) --v3
+        AND topics [0] :: STRING = '0x27c98e911efdd224f4002f6cd831c3ad0d2759ee176f9ee8466d95826af22a1c' --WooRouterSwap
+
+{% if is_incremental() %}
+AND _inserted_timestamp >= (
+    SELECT
+        MAX(_inserted_timestamp) :: DATE
+    FROM
+        {{ this }}
+)
+{% endif %}
+),
+swaps_base AS (
+    SELECT
+        l.block_number,
+        l.block_timestamp,
+        l.tx_hash,
+        origin_function_signature,
+        origin_from_address,
+        origin_to_address,
+        l.event_index,
+        l.contract_address,
+        regexp_substr_all(SUBSTR(l.data, 3, len(l.data)), '.{64}') AS l_segmented_data,
+        CONCAT('0x', SUBSTR(l.topics [1] :: STRING, 27, 40)) AS from_token,
+        CONCAT('0x', SUBSTR(l.topics [2] :: STRING, 27, 40)) AS to_token,
+        CONCAT('0x', SUBSTR(l.topics [3] :: STRING, 27, 40)) AS to_address,
+        TRY_TO_NUMBER(
+            utils.udf_hex_to_int(
+                l_segmented_data [0] :: STRING
+            )
+        ) AS fromAmount,
+        TRY_TO_NUMBER(
+            utils.udf_hex_to_int(
+                l_segmented_data [1] :: STRING
+            )
+        ) AS toAmount,
+        CONCAT(
+            '0x',
+            SUBSTR(
+                l_segmented_data [2] :: STRING,
+                25,
+                40
+            )
+        ) AS from_address,
+        CONCAT(
+            '0x',
+            SUBSTR(
+                l_segmented_data [3] :: STRING,
+                25,
+                40
+            )
+        ) AS rebateTo,
+        l._log_id,
+        l._inserted_timestamp
+    FROM
+        {{ ref('silver__logs2') }}
+        l
+    WHERE
+        contract_address IN (
+            '0x39d361e66798155813b907a70d6c2e3fdafb0877',
+            '0xc04362cf21e6285e295240e30c056511df224cf4',
+            '0x86b1742a1d7c963d3e8985829d722725316abf0a',
+            '0xeff23b4be1091b53205e35f3afcd9c7182bf3062',
+            '0xb89a33227876aef02a7ebd594af9973aece2f521',
+            '0x8693f9701d6db361fe9cc15bc455ef4366e39ae0',
+            '0x1f79f8a65e02f8a137ce7f79c038cc44332df448'
+        )
+        AND topics [0] :: STRING IN (
+            '0x74ef34e2ea7c5d9f7b7ed44e97ad44b4303416c3a660c3fb5b3bdb95a1d6abd3',
+            '0x0e8e403c2d36126272b08c75823e988381d9dc47f2f0a9a080d95f891d95c469'
+        ) --WooSwap
+        AND tx_hash NOT IN (
+            SELECT
+                tx_hash
+            FROM
+                router_swaps_base
+        )
+
+{% if is_incremental() %}
+AND _inserted_timestamp >= (
+    SELECT
+        MAX(_inserted_timestamp) :: DATE
+    FROM
+        {{ this }}
+)
+{% endif %}
+)
+SELECT
+    block_number,
+    block_timestamp,
+    tx_hash,
+    origin_function_signature,
+    origin_from_address,
+    origin_to_address,
+    event_index,
+    contract_address,
+    CASE
+        WHEN from_token = '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee' THEN '0x82af49447d8a07e3bd95bd0d56f35241523fbab1'
+        ELSE from_token
+    END AS token_in,
+    CASE
+        WHEN to_token = '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee' THEN '0x82af49447d8a07e3bd95bd0d56f35241523fbab1'
+        ELSE to_token
+    END AS token_out,
+    to_address AS tx_to,
+    swapType AS swap_type,
+    fromAmount AS amount_in_unadj,
+    toAmount AS amount_out_unadj,
+    from_address AS sender,
+    rebateTo AS rebate_to,
+    'WooRouterSwap' AS event_name,
+    'woofi' AS platform,
+    _log_id,
+    _inserted_timestamp
+FROM
+    router_swaps_base
+UNION ALL
+SELECT
+    block_number,
+    block_timestamp,
+    tx_hash,
+    origin_function_signature,
+    origin_from_address,
+    origin_to_address,
+    event_index,
+    contract_address,
+    CASE
+        WHEN from_token = '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee' THEN '0x82af49447d8a07e3bd95bd0d56f35241523fbab1'
+        ELSE from_token
+    END AS token_in,
+    CASE
+        WHEN to_token = '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee' THEN '0x82af49447d8a07e3bd95bd0d56f35241523fbab1'
+        ELSE to_token
+    END AS token_out,
+    to_address AS tx_to,
+    NULL AS swap_type,
+    fromAmount AS amount_in_unadj,
+    toAmount AS amount_out_unadj,
+    from_address AS sender,
+    rebateTo AS rebate_to,
+    'WooSwap' AS event_name,
+    'woofi' AS platform,
+    _log_id,
+    _inserted_timestamp
+FROM
+    swaps_base

--- a/models/silver/dex/woofi/silver_dex__woofi_swaps.yml
+++ b/models/silver/dex/woofi/silver_dex__woofi_swaps.yml
@@ -1,0 +1,81 @@
+version: 2
+models:
+  - name: silver_dex__woofi_swaps
+   
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - _LOG_ID
+    columns:
+      - name: BLOCK_NUMBER
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - FLOAT
+      - name: BLOCK_TIMESTAMP
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - TIMESTAMP_LTZ
+                - TIMESTAMP_NTZ
+      - name: TX_HASH
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: CONTRACT_ADDRESS
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: TOKEN_IN
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: TOKEN_OUT
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: SENDER
+        tests:
+          - not_null:
+              where: BLOCK_TIMESTAMP > '2021-08-01'
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: TX_TO
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: PLATFORM
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - STRING
+                - VARCHAR
+      - name: EVENT_INDEX
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - FLOAT
+      - name: _LOG_ID
+        tests:
+          - not_null
+      - name: ORIGIN_FUNCTION_SIGNATURE
+        tests:
+          - not_null
+      - name: ORIGIN_FROM_ADDRESS
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: ORIGIN_TO_ADDRESS
+        tests:
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+

--- a/models/silver/dex/zyberswap/silver_dex__zyberswap_pools.sql
+++ b/models/silver/dex/zyberswap/silver_dex__zyberswap_pools.sql
@@ -1,0 +1,56 @@
+{{ config(
+    materialized = 'incremental',
+    unique_key = "pool_address"
+) }}
+
+WITH pool_creation AS (
+
+    SELECT
+        block_number,
+        block_timestamp,
+        tx_hash,
+        event_index,
+        contract_address,
+        regexp_substr_all(SUBSTR(DATA, 3, len(DATA)), '.{64}') AS segmented_data,
+        CONCAT('0x', SUBSTR(topics [1] :: STRING, 27, 40)) AS token0,
+        CONCAT('0x', SUBSTR(topics [2] :: STRING, 27, 40)) AS token1,
+        CONCAT('0x', SUBSTR(segmented_data [0] :: STRING, 25, 40)) AS pool_address,
+        _log_id,
+        _inserted_timestamp
+    FROM
+        {{ ref ('silver__logs2') }}
+    WHERE
+        contract_address IN (
+            '0xac2ee06a14c52570ef3b9812ed240bce359772e7',
+            --v2
+            '0x9c2abd632771b433e5e7507bcaa41ca3b25d8544'
+        ) --v3
+        AND topics [0] :: STRING IN ('0x0d3648bd0f6ba80134a33ba9275ac585d9d315f0ad8355cddefde31afa28d0e9', --PairCreated v2
+        '0x91ccaa7a278130b65168c3a0c8d3bcae84cf5e43704342bd3ec0b59e59c036db') --v3
+
+{% if is_incremental() %}
+AND _inserted_timestamp >= (
+    SELECT
+        MAX(_inserted_timestamp) :: DATE
+    FROM
+        {{ this }}
+)
+AND pool_address NOT IN (
+    SELECT
+        DISTINCT pool_address
+    FROM
+        {{ this }}
+)
+{% endif %}
+)
+SELECT
+    block_number,
+    block_timestamp,
+    tx_hash,
+    event_index,
+    token0,
+    token1,
+    pool_address,
+    _inserted_timestamp
+FROM
+    pool_creation

--- a/models/silver/dex/zyberswap/silver_dex__zyberswap_pools.sql
+++ b/models/silver/dex/zyberswap/silver_dex__zyberswap_pools.sql
@@ -18,7 +18,7 @@ WITH pool_creation AS (
         _log_id,
         _inserted_timestamp
     FROM
-        {{ ref ('silver__logs2') }}
+        {{ ref ('silver__logs') }}
     WHERE
         contract_address IN (
             '0xac2ee06a14c52570ef3b9812ed240bce359772e7',

--- a/models/silver/dex/zyberswap/silver_dex__zyberswap_pools.yml
+++ b/models/silver/dex/zyberswap/silver_dex__zyberswap_pools.yml
@@ -1,0 +1,23 @@
+version: 2
+models:
+  - name: silver_dex__zyberswap_pools
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - POOL_ADDRESS
+    columns:
+      - name: POOL_ADDRESS
+        tests:
+          - not_null
+      - name: TOKEN0
+        tests:
+          - not_null
+      - name: TOKEN1
+        tests:
+          - not_null
+      - name: _INSERTED_TIMESTAMP
+        tests: 
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - TIMESTAMP_LTZ
+                - TIMESTAMP_NTZ

--- a/models/silver/dex/zyberswap/silver_dex__zyberswap_v2_swaps.sql
+++ b/models/silver/dex/zyberswap/silver_dex__zyberswap_v2_swaps.sql
@@ -51,7 +51,7 @@ swaps_base AS (
         _log_id,
         _inserted_timestamp
     FROM
-        {{ ref('silver__logs2') }}
+        {{ ref('silver__logs') }}
         INNER JOIN pools p
         ON p.pool_address = contract_address
     WHERE

--- a/models/silver/dex/zyberswap/silver_dex__zyberswap_v2_swaps.sql
+++ b/models/silver/dex/zyberswap/silver_dex__zyberswap_v2_swaps.sql
@@ -1,0 +1,116 @@
+{{ config(
+    materialized = 'incremental',
+    unique_key = '_log_id',
+    cluster_by = ['block_timestamp::DATE']
+) }}
+
+WITH pools AS (
+
+    SELECT
+        pool_address,
+        token0,
+        token1
+    FROM
+        {{ ref('silver_dex__zyberswap_pools') }}
+),
+swaps_base AS (
+    SELECT
+        block_number,
+        origin_function_signature,
+        origin_from_address,
+        origin_to_address,
+        block_timestamp,
+        tx_hash,
+        event_index,
+        contract_address,
+        regexp_substr_all(SUBSTR(DATA, 3, len(DATA)), '.{64}') AS segmented_data,
+        TRY_TO_NUMBER(
+            utils.udf_hex_to_int(
+                segmented_data [0] :: STRING
+            ) :: INTEGER
+        ) AS amount0In,
+        TRY_TO_NUMBER(
+            utils.udf_hex_to_int(
+                segmented_data [1] :: STRING
+            ) :: INTEGER
+        ) AS amount1In,
+        TRY_TO_NUMBER(
+            utils.udf_hex_to_int(
+                segmented_data [2] :: STRING
+            ) :: INTEGER
+        ) AS amount0Out,
+        TRY_TO_NUMBER(
+            utils.udf_hex_to_int(
+                segmented_data [3] :: STRING
+            ) :: INTEGER
+        ) AS amount1Out,
+        CONCAT('0x', SUBSTR(topics [1] :: STRING, 27, 40)) AS sender,
+        CONCAT('0x', SUBSTR(topics [2] :: STRING, 27, 40)) AS tx_to,
+        token0,
+        token1,
+        _log_id,
+        _inserted_timestamp
+    FROM
+        {{ ref('silver__logs2') }}
+        INNER JOIN pools p
+        ON p.pool_address = contract_address
+    WHERE
+        topics [0] :: STRING = '0xd78ad95fa46c994b6551d0da85fc275fe613ce37657fb8d5e3d130840159d822'
+        AND tx_status = 'SUCCESS'
+
+{% if is_incremental() %}
+AND _inserted_timestamp >= (
+    SELECT
+        MAX(_inserted_timestamp) :: DATE
+    FROM
+        {{ this }}
+)
+{% endif %}
+)
+SELECT
+    block_number,
+    block_timestamp,
+    origin_function_signature,
+    origin_from_address,
+    origin_to_address,
+    tx_hash,
+    event_index,
+    contract_address,
+    sender,
+    tx_to,
+    amount0In,
+    amount1In,
+    amount0Out,
+    amount1Out,
+    token0,
+    token1,
+    CASE
+        WHEN amount0In <> 0
+        AND amount1In <> 0
+        AND amount0Out <> 0 THEN amount1In
+        WHEN amount0In <> 0 THEN amount0In
+        WHEN amount1In <> 0 THEN amount1In
+    END AS amount_in_unadj,
+    CASE
+        WHEN amount0Out <> 0 THEN amount0Out
+        WHEN amount1Out <> 0 THEN amount1Out
+    END AS amount_out_unadj,
+    CASE
+        WHEN amount0In <> 0
+        AND amount1In <> 0
+        AND amount0Out <> 0 THEN token1
+        WHEN amount0In <> 0 THEN token0
+        WHEN amount1In <> 0 THEN token1
+    END AS token_in,
+    CASE
+        WHEN amount0Out <> 0 THEN token0
+        WHEN amount1Out <> 0 THEN token1
+    END AS token_out,
+    'Swap' AS event_name,
+    'zyberswap-v2' AS platform,
+    _log_id,
+    _inserted_timestamp
+FROM
+    swaps_base
+WHERE
+    token_in <> token_out

--- a/models/silver/dex/zyberswap/silver_dex__zyberswap_v2_swaps.yml
+++ b/models/silver/dex/zyberswap/silver_dex__zyberswap_v2_swaps.yml
@@ -1,0 +1,116 @@
+version: 2
+models:
+  - name: silver_dex__zyberswap_v2_swaps
+
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - _LOG_ID
+    columns:
+      - name: BLOCK_NUMBER
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - FLOAT
+      - name: BLOCK_TIMESTAMP
+        tests:
+          - not_null
+          - dbt_expectations.expect_row_values_to_have_recent_data:
+              datepart: day
+              interval: 2
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - TIMESTAMP_LTZ
+                - TIMESTAMP_NTZ
+      - name: TX_HASH
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: CONTRACT_ADDRESS
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: AMOUNT_IN_UNADJ
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - FLOAT
+      - name: AMOUNT_IN
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - FLOAT
+      - name: AMOUNT_OUT_UNADJ
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - FLOAT
+      - name: AMOUNT_OUT
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - FLOAT
+      - name: TOKEN_IN
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+
+      - name: TOKEN_OUT
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: SYMBOL_IN
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - STRING
+                - VARCHAR
+      - name: SYMBOL_OUT
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - STRING
+                - VARCHAR
+      - name: TX_TO
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: PLATFORM
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - STRING
+                - VARCHAR
+      - name: EVENT_INDEX
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - FLOAT
+      - name: _LOG_ID
+        tests:
+          - not_null
+      - name: ORIGIN_FUNCTION_SIGNATURE
+        tests:
+          - not_null
+      - name: ORIGIN_FROM_ADDRESS
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: ORIGIN_TO_ADDRESS
+        tests:
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+

--- a/models/silver/dex/zyberswap/silver_dex__zyberswap_v3_swaps.sql
+++ b/models/silver/dex/zyberswap/silver_dex__zyberswap_v3_swaps.sql
@@ -1,0 +1,113 @@
+{{ config(
+    materialized = 'incremental',
+    unique_key = '_log_id',
+    cluster_by = ['block_timestamp::DATE']
+) }}
+
+WITH pools AS (
+
+    SELECT
+        pool_address,
+        token0,
+        token1
+    FROM
+        {{ ref('silver_dex__zyberswap_pools') }}
+),
+swaps_base AS (
+    SELECT
+        block_number,
+        origin_function_signature,
+        origin_from_address,
+        origin_to_address,
+        block_timestamp,
+        tx_hash,
+        event_index,
+        contract_address,
+        regexp_substr_all(SUBSTR(l.data, 3, len(l.data)), '.{64}') AS l_segmented_data,
+        CONCAT('0x', SUBSTR(l.topics [1] :: STRING, 27, 40)) AS sender_address,
+        CONCAT('0x', SUBSTR(l.topics [2] :: STRING, 27, 40)) AS reipient_address,
+        TRY_TO_NUMBER(
+            utils.udf_hex_to_int(
+                's2c',
+                l_segmented_data [0] :: STRING
+            )
+        ) AS amount0,
+        TRY_TO_NUMBER(
+            utils.udf_hex_to_int(
+                's2c',
+                l_segmented_data [1] :: STRING
+            )
+        ) AS amount1,
+        TRY_TO_NUMBER(
+            utils.udf_hex_to_int(
+                l_segmented_data [2] :: STRING
+            )
+        ) AS sqrtP,
+        TRY_TO_NUMBER(
+            utils.udf_hex_to_int(
+                l_segmented_data [3] :: STRING
+            )
+        ) AS liquidity,
+        TRY_TO_NUMBER(
+            utils.udf_hex_to_int(
+                's2c',
+                l_segmented_data [4] :: STRING
+            )
+        ) AS currentTick,
+        ABS(GREATEST(amount0, amount1)) AS amountOut,
+        ABS(LEAST(amount0, amount1)) AS amountIn,
+        token0,
+        token1,
+        CASE
+            WHEN amount0 < 0 THEN token0
+            ELSE token1
+        END AS token_in,
+        CASE
+            WHEN amount0 > 0 THEN token0
+            ELSE token1
+        END AS token_out,
+        _log_id,
+        _inserted_timestamp
+    FROM
+        {{ ref('silver__logs2') }} l
+        INNER JOIN pools p
+        ON p.pool_address = contract_address
+    WHERE
+        topics [0] :: STRING = '0xc42079f94a6350d7e6235f29174924f928cc2ac818eb64fed8004e115fbcca67'
+        AND tx_status = 'SUCCESS'
+
+{% if is_incremental() %}
+AND _inserted_timestamp >= (
+    SELECT
+        MAX(_inserted_timestamp) :: DATE
+    FROM
+        {{ this }}
+)
+{% endif %}
+)
+SELECT
+    block_number,
+    block_timestamp,
+    origin_function_signature,
+    origin_from_address,
+    origin_to_address,
+    tx_hash,
+    event_index,
+    contract_address,
+    sender_address AS sender,
+    reipient_address AS tx_to,
+    amount0,
+    amount1,
+    sqrtP,
+    liquidity,
+    currentTick,
+    amountIn AS amount_in_unadj,
+    amountOut AS amount_out_unadj,
+    token_in,
+    token_out,
+    'Swap' AS event_name,
+    'zyberswap-v3' AS platform,
+    _log_id,
+    _inserted_timestamp
+FROM
+    swaps_base

--- a/models/silver/dex/zyberswap/silver_dex__zyberswap_v3_swaps.sql
+++ b/models/silver/dex/zyberswap/silver_dex__zyberswap_v3_swaps.sql
@@ -69,7 +69,7 @@ swaps_base AS (
         _log_id,
         _inserted_timestamp
     FROM
-        {{ ref('silver__logs2') }} l
+        {{ ref('silver__logs') }} l
         INNER JOIN pools p
         ON p.pool_address = contract_address
     WHERE

--- a/models/silver/dex/zyberswap/silver_dex__zyberswap_v3_swaps.yml
+++ b/models/silver/dex/zyberswap/silver_dex__zyberswap_v3_swaps.yml
@@ -1,0 +1,116 @@
+version: 2
+models:
+  - name: silver_dex__zyberswap_v3_swaps
+
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - _LOG_ID
+    columns:
+      - name: BLOCK_NUMBER
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - FLOAT
+      - name: BLOCK_TIMESTAMP
+        tests:
+          - not_null
+          - dbt_expectations.expect_row_values_to_have_recent_data:
+              datepart: day
+              interval: 2
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - TIMESTAMP_LTZ
+                - TIMESTAMP_NTZ
+      - name: TX_HASH
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: CONTRACT_ADDRESS
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: AMOUNT_IN_UNADJ
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - FLOAT
+      - name: AMOUNT_IN
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - FLOAT
+      - name: AMOUNT_OUT_UNADJ
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - FLOAT
+      - name: AMOUNT_OUT
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - FLOAT
+      - name: TOKEN_IN
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+
+      - name: TOKEN_OUT
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: SYMBOL_IN
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - STRING
+                - VARCHAR
+      - name: SYMBOL_OUT
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - STRING
+                - VARCHAR
+      - name: TX_TO
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: PLATFORM
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - STRING
+                - VARCHAR
+      - name: EVENT_INDEX
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - FLOAT
+      - name: _LOG_ID
+        tests:
+          - not_null
+      - name: ORIGIN_FUNCTION_SIGNATURE
+        tests:
+          - not_null
+      - name: ORIGIN_FROM_ADDRESS
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: ORIGIN_TO_ADDRESS
+        tests:
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+


### PR DESCRIPTION
1. Added new pools/swaps models across 12+ dexes, providing near-full DEX coverage
2. Updated `complete_dex_swaps` and `ez_dex_swaps` and documentation
5. FR+ required on `models/silver/dex+`  with `dbt_run_deployment`