### PR TITLE
fix/txn-dupes

### DIFF
--- a/models/silver/_observability/silver_observability__excluded_receipt_blocks.sql
+++ b/models/silver/_observability/silver_observability__excluded_receipt_blocks.sql
@@ -2,11 +2,10 @@
     materialized = 'view'
 ) }}
 
+SELECT 
+    15458950 AS block_number, 
+    '0xf135954c7b2a17c094f917fff69aa215fa9af86443e55f167e701e39afa5ff0f' AS tx_hash
+UNION ALL
 SELECT
-    column1 AS block_number
-FROM
-    (
-        VALUES
-            (4527955),
-            (15458950)
-    ) AS block_number(column1)
+    4527955,
+    '0x1d76d3d13e9f8cc713d484b0de58edd279c4c62e46e963899aec28eb648b5800'

--- a/models/silver/core/silver__transactions.sql
+++ b/models/silver/core/silver__transactions.sql
@@ -309,7 +309,53 @@ FROM
 {% endif %}
 )
 SELECT
-    *
+    block_number,
+    block_hash,
+    chain_id,
+    from_address,
+    gas,
+    gas_price,
+    tx_hash,
+    input_data,
+    origin_function_signature,
+    max_fee_per_gas,
+    max_priority_fee_per_gas,
+    nonce,
+    r,
+    s,
+    to_address,
+    POSITION,
+    TYPE,
+    v,
+    VALUE,
+    block_timestamp,
+    CASE
+        WHEN CONCAT(
+            block_number,
+            '-',
+            tx_hash
+        ) IN (
+            SELECT
+                CONCAT(
+                    block_number,
+                    '-',
+                    tx_hash
+                )
+            FROM
+                {{ ref('silver_observability__excluded_receipt_blocks') }}
+        ) THEN FALSE
+        ELSE is_pending
+    END AS is_pending,
+    gas_used,
+    tx_success,
+    tx_status,
+    cumulative_gas_used,
+    effective_gas_price,
+    tx_fee,
+    tx_type,
+    l1_block_number,
+    gas_used_for_l1,
+    _inserted_timestamp
 FROM
     FINAL qualify(ROW_NUMBER() over (PARTITION BY block_number, POSITION
 ORDER BY

--- a/models/silver/core/silver__transactions.sql
+++ b/models/silver/core/silver__transactions.sql
@@ -234,6 +234,16 @@ missing_data AS (
         t.is_pending
 )
 {% endif %},
+exclusions AS (
+    SELECT
+        CONCAT(
+            block_number,
+            '-',
+            tx_hash
+        ) AS block_tx_id
+    FROM
+        {{ ref('silver_observability__excluded_receipt_blocks') }}
+),
 FINAL AS (
     SELECT
         block_number,
@@ -336,13 +346,9 @@ SELECT
             tx_hash
         ) IN (
             SELECT
-                CONCAT(
-                    block_number,
-                    '-',
-                    tx_hash
-                )
+                block_tx_id
             FROM
-                {{ ref('silver_observability__excluded_receipt_blocks') }}
+                exclusions
         ) THEN FALSE
         ELSE is_pending
     END AS is_pending,


### PR DESCRIPTION
1. requires `dbt run -m models/silver/_observability/silver_observability__excluded_receipt_blocks.sql --full-refresh`
2. drop impacted blocks from complete models
3. run streamline history job