### PR TITLE
fix/gmx-fees

### DIFF
--- a/models/silver/defi/dex/gmx/silver_dex__gmx_swaps.sql
+++ b/models/silver/defi/dex/gmx/silver_dex__gmx_swaps.sql
@@ -9,19 +9,19 @@
 WITH swaps_base AS (
 
     SELECT
-        l.block_number,
-        l.block_timestamp,
-        l.tx_hash,
+        block_number,
+        block_timestamp,
+        tx_hash,
         origin_function_signature,
         origin_from_address,
         origin_to_address,
-        l.event_index,
-        l.contract_address,
-        regexp_substr_all(SUBSTR(l.data, 3, len(l.data)), '.{64}') AS l_segmented_data,
+        event_index,
+        contract_address,
+        regexp_substr_all(SUBSTR(DATA, 3, len(DATA)), '.{64}') AS segmented_data,
         CONCAT(
             '0x',
             SUBSTR(
-                l_segmented_data [0] :: STRING,
+                segmented_data [0] :: STRING,
                 25,
                 40
             )
@@ -29,7 +29,7 @@ WITH swaps_base AS (
         CONCAT(
             '0x',
             SUBSTR(
-                l_segmented_data [1] :: STRING,
+                segmented_data [1] :: STRING,
                 25,
                 40
             )
@@ -37,31 +37,38 @@ WITH swaps_base AS (
         CONCAT(
             '0x',
             SUBSTR(
-                l_segmented_data [2] :: STRING,
+                segmented_data [2] :: STRING,
                 25,
                 40
             )
         ) AS tokenOut,
         TRY_TO_NUMBER(
             utils.udf_hex_to_int(
-                l_segmented_data [3] :: STRING
+                segmented_data [3] :: STRING
             )
         ) AS amountIn,
         TRY_TO_NUMBER(
             utils.udf_hex_to_int(
-                l_segmented_data [4] :: STRING
+                segmented_data [4] :: STRING
             )
         ) AS amountOut,
-        l._log_id,
-        l._inserted_timestamp
+        TRY_TO_NUMBER(
+            utils.udf_hex_to_int(
+                segmented_data [5] :: STRING
+            )
+        ) AS amountOutAfterFees,
+        TRY_TO_NUMBER(
+            utils.udf_hex_to_int(
+                segmented_data [6] :: STRING
+            )
+        ) AS feeBasisPoints,
+        _log_id,
+        _inserted_timestamp
     FROM
         {{ ref('silver__logs') }}
-        l
     WHERE
-        contract_address IN (
-            '0xabbc5f99639c9b6bcb58544ddf04efa6802f4064'
-        )
-        AND topics [0] :: STRING = '0xcd3829a3813dc3cdd188fd3d01dcf3268c16be2fdd2dd21d0665418816e46062' --Swap
+        contract_address = '0x489ee077994b6658eafa855c308275ead8097c4a'
+        AND topics [0] :: STRING = '0x0874b2d545cb271cdbda4e093020c452328b24af12382ed62c4d00f5c26709db'
 
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
@@ -86,7 +93,7 @@ SELECT
     tokenIn AS token_in,
     tokenOut AS token_out,
     amountIn AS amount_in_unadj,
-    amountOut AS amount_out_unadj,
+    amountOutAfterFees AS amount_out_unadj,
     'Swap' AS event_name,
     'gmx' AS platform,
     _log_id,

--- a/models/silver/defi/dex/silver_dex__complete_dex_swaps.sql
+++ b/models/silver/defi/dex/silver_dex__complete_dex_swaps.sql
@@ -123,7 +123,7 @@ univ3_swaps AS (
       block_timestamp
     ) = p2.hour
 
-{% if is_incremental() %}
+{% if is_incremental() and 'univ3_swaps' not in var('HEAL_CURATED_MODEL') %}
 WHERE
   _inserted_timestamp >= (
     SELECT
@@ -175,7 +175,7 @@ balancer_swaps AS (
     LEFT JOIN contracts c2
     ON s.token_out = c2.address
 
-{% if is_incremental() %}
+{% if is_incremental() and 'balancer_swaps' not in var('HEAL_CURATED_MODEL') %}
 WHERE
   _inserted_timestamp >= (
     SELECT
@@ -245,7 +245,7 @@ curve_swaps AS (
       'null'
     ) <> COALESCE(token_symbol_out, 'null')
 
-{% if is_incremental() %}
+{% if is_incremental() and 'curve_swaps' not in var('HEAL_CURATED_MODEL') %}
 AND _inserted_timestamp >= (
   SELECT
     MAX(_inserted_timestamp) - INTERVAL '12 hours'
@@ -296,7 +296,7 @@ trader_joe_v1_swaps AS (
     LEFT JOIN contracts c2
     ON s.token_out = c2.address
 
-{% if is_incremental() %}
+{% if is_incremental() and 'trader_joe_v1_swaps' not in var('HEAL_CURATED_MODEL') %}
 WHERE
   _inserted_timestamp >= (
     SELECT
@@ -348,7 +348,7 @@ trader_joe_v2_swaps AS (
     LEFT JOIN contracts c2
     ON s.token_out = c2.address
 
-{% if is_incremental() %}
+{% if is_incremental() and 'trader_joe_v2_swaps' not in var('HEAL_CURATED_MODEL') %}
 WHERE
   _inserted_timestamp >= (
     SELECT
@@ -400,7 +400,7 @@ trader_joe_v2_1_swaps AS (
     LEFT JOIN contracts c2
     ON s.token_out = c2.address
 
-{% if is_incremental() %}
+{% if is_incremental() and 'trader_joe_v2_1_swaps' not in var('HEAL_CURATED_MODEL') %}
 WHERE
   _inserted_timestamp >= (
     SELECT
@@ -462,7 +462,7 @@ woofi_swaps AS (
     LEFT JOIN contracts c2
     ON s.token_out = c2.address
 
-{% if is_incremental() %}
+{% if is_incremental() and 'woofi_swaps' not in var('HEAL_CURATED_MODEL') %}
 WHERE
   _inserted_timestamp >= (
     SELECT
@@ -524,7 +524,7 @@ hashflow_swaps AS (
     LEFT JOIN contracts c2
     ON s.token_out = c2.address
 
-{% if is_incremental() %}
+{% if is_incremental() and 'hashflow_swaps' not in var('HEAL_CURATED_MODEL') %}
 WHERE
   _inserted_timestamp >= (
     SELECT
@@ -586,7 +586,7 @@ hashflow_v3_swaps AS (
     LEFT JOIN contracts c2
     ON s.token_out = c2.address
 
-{% if is_incremental() %}
+{% if is_incremental() and 'hashflow_v3_swaps' not in var('HEAL_CURATED_MODEL') %}
 WHERE
   _inserted_timestamp >= (
     SELECT
@@ -648,7 +648,7 @@ gmx_swaps AS (
     LEFT JOIN contracts c2
     ON s.token_out = c2.address
 
-{% if is_incremental() %}
+{% if is_incremental() and 'gmx_swaps' not in var('HEAL_CURATED_MODEL') %}
 WHERE
   _inserted_timestamp >= (
     SELECT
@@ -700,7 +700,7 @@ kyberswap_v1_dynamic AS (
     LEFT JOIN contracts c2
     ON s.token_out = c2.address
 
-{% if is_incremental() %}
+{% if is_incremental() and 'kyberswap_v1_dynamic' not in var('HEAL_CURATED_MODEL') %}
 WHERE
   _inserted_timestamp >= (
     SELECT
@@ -752,7 +752,7 @@ kyberswap_v1_static AS (
     LEFT JOIN contracts c2
     ON s.token_out = c2.address
 
-{% if is_incremental() %}
+{% if is_incremental() and 'kyberswap_v1_static' not in var('HEAL_CURATED_MODEL') %}
 WHERE
   _inserted_timestamp >= (
     SELECT
@@ -804,7 +804,7 @@ kyberswap_v2_elastic AS (
     LEFT JOIN contracts c2
     ON s.token_out = c2.address
 
-{% if is_incremental() %}
+{% if is_incremental() and 'kyberswap_v2_elastic' not in var('HEAL_CURATED_MODEL') %}
 WHERE
   _inserted_timestamp >= (
     SELECT
@@ -856,7 +856,7 @@ fraxswap_swaps AS (
     LEFT JOIN contracts c2
     ON s.token_out = c2.address
 
-{% if is_incremental() %}
+{% if is_incremental() and 'fraxswap_swaps' not in var('HEAL_CURATED_MODEL') %}
 WHERE
   _inserted_timestamp >= (
     SELECT
@@ -908,7 +908,7 @@ sushi_swaps AS (
     LEFT JOIN contracts c2
     ON s.token_out = c2.address
 
-{% if is_incremental() %}
+{% if is_incremental() and 'sushi_swaps' not in var('HEAL_CURATED_MODEL') %}
 WHERE
   _inserted_timestamp >= (
     SELECT
@@ -960,7 +960,7 @@ dodo_v1_swaps AS (
     LEFT JOIN contracts c2
     ON s.token_out = c2.address
 
-{% if is_incremental() %}
+{% if is_incremental() and 'dodo_v1_swaps' not in var('HEAL_CURATED_MODEL') %}
 WHERE
   _inserted_timestamp >= (
     SELECT
@@ -1012,7 +1012,7 @@ dodo_v2_swaps AS (
     LEFT JOIN contracts c2
     ON s.token_out = c2.address
 
-{% if is_incremental() %}
+{% if is_incremental() and 'dodo_v2_swaps' not in var('HEAL_CURATED_MODEL') %}
 WHERE
   _inserted_timestamp >= (
     SELECT
@@ -1064,7 +1064,7 @@ camelot_v2_swaps AS (
     LEFT JOIN contracts c2
     ON s.token_out = c2.address
 
-{% if is_incremental() %}
+{% if is_incremental() and 'camelot_v2_swaps' not in var('HEAL_CURATED_MODEL') %}
 WHERE
   _inserted_timestamp >= (
     SELECT
@@ -1116,7 +1116,7 @@ camelot_v3_swaps AS (
     LEFT JOIN contracts c2
     ON s.token_out = c2.address
 
-{% if is_incremental() %}
+{% if is_incremental() and 'camelot_v3_swaps' not in var('HEAL_CURATED_MODEL') %}
 WHERE
   _inserted_timestamp >= (
     SELECT
@@ -1168,7 +1168,7 @@ zyberswap_v2_swaps AS (
     LEFT JOIN contracts c2
     ON s.token_out = c2.address
 
-{% if is_incremental() %}
+{% if is_incremental() and 'zyberswap_v2_swaps' not in var('HEAL_CURATED_MODEL') %}
 WHERE
   _inserted_timestamp >= (
     SELECT
@@ -1220,7 +1220,7 @@ zyberswap_v3_swaps AS (
     LEFT JOIN contracts c2
     ON s.token_out = c2.address
 
-{% if is_incremental() %}
+{% if is_incremental() and 'zyberswap_v3_swaps' not in var('HEAL_CURATED_MODEL') %}
 WHERE
   _inserted_timestamp >= (
     SELECT


### PR DESCRIPTION
1. Updates gmx swaps with different event for more accurate coverage
2. Adds heal variable to complete

`dbt run -m models/silver/defi/dex/gmx/silver_dex__gmx_swaps.sql --full-refresh && dbt run -m models/silver/defi/dex/silver_dex__complete_dex_swaps.sql --var '{"HEAL_CURATED_MODEL":"gmx_swaps"}'`