### PR TITLE
AN-4820/heal-logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Use a variable to negate incremental logic:
 Use a variable to extend the incremental lookback period:
 * LOOKBACK
   * Default is a string representing the specified time interval e.g. '12 hours', '7 days' etc.
-  * Example set up: `SELECT MAX(_inserted_timestamp) - INTERVAL '{{ var('LOOKBACK', '4 hours') }}'`
+  * Example set up: `SELECT MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'`
 
   * Usage: `dbt run --vars '{"LOOKBACK":"36 hours"}' -m ...`
 

--- a/README.md
+++ b/README.md
@@ -34,36 +34,43 @@ arbitrum:
       client_session_keep_alive: False
       query_tag: <TAG>
 ```
-### Variables
+## Variables
 
 To control the creation of UDF or SP macros with dbt run:
 * UPDATE_UDFS_AND_SPS
-When True, executes all macros included in the on-run-start hooks within dbt_project.yml on model run as normal
-When False, none of the on-run-start macros are executed on model run
+  * Default values are False
+  * When True, executes all macros included in the on-run-start hooks within dbt_project.yml on model run as normal
+  * When False, none of the on-run-start macros are executed on model run
 
-Default values are False
+  * Usage: `dbt run --vars '{"UPDATE_UDFS_AND_SPS":True}' -m ...`
 
-* Usage:
-dbt run --var '{"UPDATE_UDFS_AND_SPS":True}'  -m ...
+Use a variable to heal a model incrementally:
+* HEAL_MODEL
+  * Default is FALSE (Boolean)
+  * When FALSE, logic will be negated
+  * When TRUE, heal logic will apply
+  * Include `heal` in model tags within the config block for inclusion in the `dbt_run_heal_models` workflow, e.g. `tags = 'heal'`
 
-To reload records in a curated complete table without a full-refresh, such as `silver_bridge.complete_bridge_activity`:
-* HEAL_CURATED_MODEL
-Default is an empty array []
-When item is included in var array [], incremental logic will be skipped for that CTE / code block  
-When item is not included in var array [] or does not match specified item in model, incremental logic will apply
-Example set up: `{% if is_incremental() and 'axelar' not in var('HEAL_CURATED_MODEL') %}`
+  * Usage: `dbt run --vars '{"HEAL_MODEL":True}' -m ...`
 
-* Usage:
-Single CTE: dbt run --var '{"HEAL_CURATED_MODEL":"axelar"}' -m ...
-Multiple CTEs: dbt run --var '{"HEAL_CURATED_MODEL":["axelar","across","celer_cbridge"]}' -m ...
+Use a variable to negate incremental logic:
+* Example use case: reload records in a curated complete table without a full-refresh, such as `silver_bridge.complete_bridge_activity`:
+* HEAL_MODELS
+  * Default is an empty array []
+  * When item is included in var array [], incremental logic will be skipped for that CTE / code block  
+  * When item is not included in var array [] or does not match specified item in model, incremental logic will apply
+  * Example set up: `{% if is_incremental() and 'axelar' not in var('HEAL_MODELS') %}`
 
-### Resources:
-- Learn more about dbt [in the docs](https://docs.getdbt.com/docs/introduction)
-- Check out [Discourse](https://discourse.getdbt.com/) for commonly asked questions and answers
-- Join the [chat](https://community.getdbt.com/) on Slack for live discussions and support
-- Find [dbt events](https://events.getdbt.com) near you
-- Check out [the blog](https://blog.getdbt.com/) for the latest news on dbt's development and best practices
+  * Usage:
+    * Single CTE: `dbt run --vars '{"HEAL_MODELS":"axelar"}' -m ...`
+    * Multiple CTEs: `dbt run --vars '{"HEAL_MODELS":["axelar","across","celer_cbridge"]}' -m ...`
 
+Use a variable to extend the incremental lookback period:
+* LOOKBACK
+  * Default is a string representing the specified time interval e.g. '12 hours', '7 days' etc.
+  * Example set up: `SELECT MAX(_inserted_timestamp) - INTERVAL '{{ var('LOOKBACK', '4 hours') }}'`
+
+  * Usage: `dbt run --vars '{"LOOKBACK":"36 hours"}' -m ...`
 
 ## Applying Model Tags
 
@@ -97,7 +104,7 @@ To add/update a model's snowflake tags, add/modify the `meta` model property und
 By default, model tags are pushed to Snowflake on each load. You can disable this by setting the `UPDATE_SNOWFLAKE_TAGS` project variable to `False` during a run.
 
 ```
-dbt run --var '{"UPDATE_SNOWFLAKE_TAGS":False}' -s models/core/core__fact_blocks.sql
+dbt run --vars '{"UPDATE_SNOWFLAKE_TAGS":False}' -s models/core/core__fact_blocks.sql
 ```
 
 ### Querying for existing tags on a model in snowflake
@@ -106,3 +113,10 @@ dbt run --var '{"UPDATE_SNOWFLAKE_TAGS":False}' -s models/core/core__fact_blocks
 select *
 from table(arbitrum.information_schema.tag_references('arbitrum.core.fact_blocks', 'table'));
 ```
+
+### Resources:
+- Learn more about dbt [in the docs](https://docs.getdbt.com/docs/introduction)
+- Check out [Discourse](https://discourse.getdbt.com/) for commonly asked questions and answers
+- Join the [chat](https://community.getdbt.com/) on Slack for live discussions and support
+- Find [dbt events](https://events.getdbt.com) near you
+- Check out [the blog](https://blog.getdbt.com/) for the latest news on dbt's development and best practices

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -65,7 +65,7 @@ vars:
   WAIT: 0
   OBSERV_FULL_TEST: False
   HEAL_MODEL: False
-  HEAL_CURATED_MODEL: []
+  HEAL_MODELS: []
   START_GHA_TASKS: False
   API_INTEGRATION: '{{ var("config")[target.name]["API_INTEGRATION"] if var("config")[target.name] else var("config")["dev"]["API_INTEGRATION"] }}' 
   EXTERNAL_FUNCTION_URI: '{{ var("config")[target.name]["EXTERNAL_FUNCTION_URI"] if var("config")[target.name] else var("config")["dev"]["EXTERNAL_FUNCTION_URI"] }}'

--- a/models/gold/defi/defi__ez_bridge_activity.sql
+++ b/models/gold/defi/defi__ez_bridge_activity.sql
@@ -33,7 +33,13 @@ SELECT
     token_symbol,
     amount_unadj,
     amount,
-    amount_usd,
+    ROUND(
+        CASE
+            WHEN amount_usd < 1e+15 THEN amount_usd
+            ELSE NULL
+        END,
+        2
+    ) AS amount_usd,
     COALESCE (
         complete_bridge_activity_id,
         {{ dbt_utils.generate_surrogate_key(

--- a/models/gold/defi/defi__ez_dex_swaps.sql
+++ b/models/gold/defi/defi__ez_dex_swaps.sql
@@ -24,10 +24,26 @@ SELECT
   event_name,
   amount_in_unadj,
   amount_in,
-  amount_in_usd,
+  ROUND(
+        CASE
+            WHEN amount_out_usd IS NULL
+            OR ABS((amount_in_usd - amount_out_usd) / NULLIF(amount_out_usd, 0)) > 0.75
+            OR ABS((amount_in_usd - amount_out_usd) / NULLIF(amount_in_usd, 0)) > 0.75 THEN NULL
+            ELSE amount_in_usd
+        END,
+        2
+    ) AS amount_in_usd,
   amount_out_unadj,
   amount_out,
-  amount_out_usd,
+  ROUND(
+        CASE
+            WHEN amount_in_usd IS NULL
+            OR ABS((amount_out_usd - amount_in_usd) / NULLIF(amount_in_usd, 0)) > 0.75
+            OR ABS((amount_out_usd - amount_in_usd) / NULLIF(amount_out_usd, 0)) > 0.75 THEN NULL
+            ELSE amount_out_usd
+        END,
+        2
+    ) AS amount_out_usd,
   sender,
   tx_to,
   event_index,

--- a/models/silver/core/silver__transfers.sql
+++ b/models/silver/core/silver__transfers.sql
@@ -35,7 +35,7 @@ AND _inserted_timestamp >= (
     SELECT
         MAX(
             _inserted_timestamp
-        ) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
+        ) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
     FROM
         {{ this }}
 )
@@ -169,7 +169,7 @@ heal_model AS (
                     SELECT
                         MAX(
                             _inserted_timestamp
-                        ) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
+                        ) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
                     FROM
                         {{ this }}
                 )
@@ -195,7 +195,7 @@ heal_model AS (
                             SELECT
                                 MAX(
                                     _inserted_timestamp
-                                ) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
+                                ) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
                             FROM
                                 {{ this }}
                         )

--- a/models/silver/core/silver__transfers.sql
+++ b/models/silver/core/silver__transfers.sql
@@ -35,7 +35,7 @@ AND _inserted_timestamp >= (
     SELECT
         MAX(
             _inserted_timestamp
-        ) - INTERVAL '36 hours'
+        ) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
     FROM
         {{ this }}
 )
@@ -169,7 +169,7 @@ heal_model AS (
                     SELECT
                         MAX(
                             _inserted_timestamp
-                        ) - INTERVAL '36 hours'
+                        ) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
                     FROM
                         {{ this }}
                 )
@@ -195,7 +195,7 @@ heal_model AS (
                             SELECT
                                 MAX(
                                     _inserted_timestamp
-                                ) - INTERVAL '36 hours'
+                                ) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
                             FROM
                                 {{ this }}
                         )

--- a/models/silver/defi/bridge/across/silver_bridge__across_fundsdeposited.sql
+++ b/models/silver/defi/bridge/across/silver_bridge__across_fundsdeposited.sql
@@ -52,6 +52,7 @@ WITH base_evt AS (
     WHERE
         topics [0] :: STRING = '0xafc4df6845a4ab948b492800d3d8a25d538a102a2bc07cd01f1cfa097fddcff6'
         AND contract_address = '0xe35e9842fceaca96570b734083f4a58e8f7c5f2a'
+        AND tx_status = 'SUCCESS'
 
 {% if is_incremental() %}
 AND _inserted_timestamp >= (

--- a/models/silver/defi/bridge/across/silver_bridge__across_v3fundsdeposited.sql
+++ b/models/silver/defi/bridge/across/silver_bridge__across_v3fundsdeposited.sql
@@ -60,6 +60,7 @@ WITH base_evt AS (
     WHERE
         topics [0] :: STRING = '0xa123dc29aebf7d0c3322c8eeb5b999e859f39937950ed31056532713d0de396f'
         AND contract_address = '0xe35e9842fceaca96570b734083f4a58e8f7c5f2a'
+        AND tx_status = 'SUCCESS'
 
 {% if is_incremental() %}
 AND _inserted_timestamp >= (

--- a/models/silver/defi/bridge/axelar/silver_bridge__axelar_contractcallwithtoken.sql
+++ b/models/silver/defi/bridge/axelar/silver_bridge__axelar_contractcallwithtoken.sql
@@ -42,6 +42,7 @@ WITH base_evt AS (
     WHERE
         topics [0] :: STRING = '0x7e50569d26be643bda7757722291ec66b1be66d8283474ae3fab5a98f878a7a2'
         AND contract_address = '0xe432150cce91c13a887f7d836923d5597add8e31'
+        AND tx_status = 'SUCCESS'
 
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
@@ -89,6 +90,7 @@ native_gas_paid AS (
     WHERE
         topics [0] :: STRING = '0x999d431b58761213cf53af96262b67a069cbd963499fd8effd1e21556217b841'
         AND contract_address = '0x2d5d7d31f671f86c782533cc367f14109a082712'
+        AND tx_status = 'SUCCESS'
 
 {% if is_incremental() %}
 AND _inserted_timestamp >= (

--- a/models/silver/defi/bridge/celer/silver_bridge__celer_cbridge_send.sql
+++ b/models/silver/defi/bridge/celer/silver_bridge__celer_cbridge_send.sql
@@ -49,6 +49,7 @@ WITH base_evt AS (
             '0xdd90e5e87a2081dcf0391920868ebc2ffb81a1af',
             '0x1619de6b6b20ed217a58d00f37b9d47c7663feca'
         )
+        AND tx_status = 'SUCCESS'
 
 {% if is_incremental() %}
 AND _inserted_timestamp >= (

--- a/models/silver/defi/bridge/dln/silver_bridge__dln_debridge_createdorder.sql
+++ b/models/silver/defi/bridge/dln/silver_bridge__dln_debridge_createdorder.sql
@@ -70,6 +70,7 @@ WITH base_evt AS (
     WHERE
         topics [0] :: STRING = '0xfc8703fd57380f9dd234a89dce51333782d49c5902f307b02f03e014d18fe471' --CreatedOrder
         AND contract_address = '0xef4fb24ad0916217251f553c0596f8edc630eb66' --Dln: Source
+        AND tx_status = 'SUCCESS'
 
 {% if is_incremental() %}
 AND _inserted_timestamp >= (

--- a/models/silver/defi/bridge/eywa/silver_bridge__eywa_requestsent.sql
+++ b/models/silver/defi/bridge/eywa/silver_bridge__eywa_requestsent.sql
@@ -40,6 +40,7 @@ WITH base_evt AS (
             --PortalV2
             '0xbf0b5d561b986809924f88099c4ff0e6bcce60c9' --PortalV2
         )
+        AND tx_status = 'SUCCESS'
 
 {% if is_incremental() %}
 AND _inserted_timestamp >= (

--- a/models/silver/defi/bridge/hop/silver_bridge__hop_ammwrapper.sql
+++ b/models/silver/defi/bridge/hop/silver_bridge__hop_ammwrapper.sql
@@ -14,6 +14,7 @@ WITH base_contracts AS (
         {{ ref('silver__logs') }}
     WHERE
         topics [0] :: STRING = '0xe35dddd4ea75d7e9b3fe93af4f4e40e778c3da4074c9d93e7c6536f1e803c1eb'
+        AND tx_status = 'SUCCESS'
 
 {% if is_incremental() %}
 AND _inserted_timestamp >= (

--- a/models/silver/defi/bridge/hop/silver_bridge__hop_transfersent.sql
+++ b/models/silver/defi/bridge/hop/silver_bridge__hop_transfersent.sql
@@ -51,6 +51,7 @@ WITH base_evt AS (
     WHERE
         topics [0] :: STRING = '0xe35dddd4ea75d7e9b3fe93af4f4e40e778c3da4074c9d93e7c6536f1e803c1eb'
         AND origin_to_address IS NOT NULL
+        AND tx_status = 'SUCCESS'
 
 {% if is_incremental() %}
 AND _inserted_timestamp >= (

--- a/models/silver/defi/bridge/meson/silver_bridge__meson_transfers.sql
+++ b/models/silver/defi/bridge/meson/silver_bridge__meson_transfers.sql
@@ -126,6 +126,7 @@ dst_info AS (
     WHERE
         contract_address = '0x25ab3efd52e6470681ce037cd546dc60726948d3'
         AND topics [0] :: STRING = '0x5ce4019f772fda6cb703b26bce3ec3006eb36b73f1d3a0eb441213317d9f5e9d'
+        AND tx_status = 'SUCCESS'
 
 {% if is_incremental() %}
 AND _inserted_timestamp >= (

--- a/models/silver/defi/bridge/multichain/silver_bridge__multichain_v7_loganyswapout.sql
+++ b/models/silver/defi/bridge/multichain/silver_bridge__multichain_v7_loganyswapout.sql
@@ -40,6 +40,7 @@ WITH base_evt AS (
     WHERE
         topics [0] :: STRING = '0x0d969ae475ff6fcaf0dcfa760d4d8607244e8d95e9bf426f8d5d69f9a3e525af'
         AND contract_address = '0x1633d66ca91ce4d81f63ea047b7b19beb92df7f3'
+        AND tx_status = 'SUCCESS'
 
 {% if is_incremental() %}
 AND _inserted_timestamp >= (

--- a/models/silver/defi/bridge/silver_bridge__complete_bridge_activity.sql
+++ b/models/silver/defi/bridge/silver_bridge__complete_bridge_activity.sql
@@ -38,7 +38,7 @@ WITH across AS (
 WHERE
     _inserted_timestamp >= (
         SELECT
-            MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
+            MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
         FROM
             {{ this }}
     )
@@ -74,7 +74,7 @@ across_v3 AS (
 WHERE
     _inserted_timestamp >= (
         SELECT
-            MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
+            MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
         FROM
             {{ this }}
     )
@@ -110,7 +110,7 @@ axelar AS (
 WHERE
     _inserted_timestamp >= (
         SELECT
-            MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
+            MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
         FROM
             {{ this }}
     )
@@ -146,7 +146,7 @@ celer_cbridge AS (
 WHERE
     _inserted_timestamp >= (
         SELECT
-            MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
+            MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
         FROM
             {{ this }}
     )
@@ -182,7 +182,7 @@ dln_debridge AS (
 WHERE
     _inserted_timestamp >= (
         SELECT
-            MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
+            MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
         FROM
             {{ this }}
     )
@@ -218,7 +218,7 @@ eywa AS (
 WHERE
     _inserted_timestamp >= (
         SELECT
-            MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
+            MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
         FROM
             {{ this }}
     )
@@ -254,7 +254,7 @@ hop AS (
 WHERE
     _inserted_timestamp >= (
         SELECT
-            MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
+            MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
         FROM
             {{ this }}
     )
@@ -290,7 +290,7 @@ meson AS (
 WHERE
     _inserted_timestamp >= (
         SELECT
-            MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
+            MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
         FROM
             {{ this }}
     )
@@ -326,7 +326,7 @@ multichain AS (
 WHERE
     _inserted_timestamp >= (
         SELECT
-            MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
+            MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
         FROM
             {{ this }}
     )
@@ -362,7 +362,7 @@ stargate AS (
 WHERE
     _inserted_timestamp >= (
         SELECT
-            MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
+            MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
         FROM
             {{ this }}
     )
@@ -398,7 +398,7 @@ symbiosis AS (
 WHERE
     _inserted_timestamp >= (
         SELECT
-            MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
+            MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
         FROM
             {{ this }}
     )
@@ -434,7 +434,7 @@ synapse_tb AS (
 WHERE
     _inserted_timestamp >= (
         SELECT
-            MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
+            MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
         FROM
             {{ this }}
     )
@@ -470,7 +470,7 @@ synapse_tbs AS (
 WHERE
     _inserted_timestamp >= (
         SELECT
-            MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
+            MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
         FROM
             {{ this }}
     )
@@ -506,7 +506,7 @@ wormhole AS (
 WHERE
     _inserted_timestamp >= (
         SELECT
-            MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
+            MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
         FROM
             {{ this }}
     )
@@ -776,7 +776,7 @@ heal_model AS (
                     SELECT
                         MAX(
                             _inserted_timestamp
-                        ) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
+                        ) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
                     FROM
                         {{ this }}
                 )
@@ -816,7 +816,7 @@ heal_model AS (
                             SELECT
                                 MAX(
                                     _inserted_timestamp
-                                ) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
+                                ) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
                             FROM
                                 {{ this }}
                         )

--- a/models/silver/defi/bridge/silver_bridge__complete_bridge_activity.sql
+++ b/models/silver/defi/bridge/silver_bridge__complete_bridge_activity.sql
@@ -45,7 +45,6 @@ WHERE
 {% endif %}
 ),
 across_v3 AS (
-
     SELECT
         block_number,
         block_timestamp,
@@ -535,7 +534,7 @@ all_protocols AS (
         celer_cbridge
     UNION ALL
     SELECT
-    *
+        *
     FROM
         dln_debridge
     UNION ALL
@@ -584,7 +583,7 @@ all_protocols AS (
     FROM
         wormhole
 ),
-FINAL AS (
+complete_bridge_activity AS (
     SELECT
         block_number,
         block_timestamp,
@@ -665,6 +664,198 @@ FINAL AS (
         ) = LOWER(
             b.destination_chain
         )
+),
+
+{% if is_incremental() and var(
+    'HEAL_MODEL'
+) %}
+heal_model AS (
+    SELECT
+        block_number,
+        block_timestamp,
+        origin_from_address,
+        origin_to_address,
+        origin_function_signature,
+        tx_hash,
+        event_index,
+        bridge_address,
+        event_name,
+        platform,
+        version,
+        sender,
+        receiver,
+        destination_chain_receiver,
+        CASE
+            WHEN platform IN (
+                'stargate',
+                'wormhole',
+                'meson'
+            ) THEN destination_chain_id :: STRING
+            WHEN d.chain_id IS NULL THEN destination_chain_id :: STRING
+            ELSE d.chain_id :: STRING
+        END AS destination_chain_id,
+        CASE
+            WHEN platform IN (
+                'stargate',
+                'wormhole',
+                'meson'
+            ) THEN LOWER(destination_chain)
+            WHEN d.chain IS NULL THEN LOWER(destination_chain)
+            ELSE LOWER(
+                d.chain
+            )
+        END AS destination_chain,
+        t0.token_address,
+        CASE
+            WHEN platform = 'axelar' THEN COALESCE(
+                C.token_symbol,
+                t0.token_symbol
+            )
+            ELSE C.token_symbol
+        END AS token_symbol,
+        C.token_decimals AS token_decimals,
+        amount_unadj,
+        CASE
+            WHEN C.token_decimals IS NOT NULL THEN (amount_unadj / pow(10, C.token_decimals))
+            ELSE amount_unadj
+        END AS amount,
+        CASE
+            WHEN C.token_decimals IS NOT NULL THEN ROUND(
+                amount * p.price,
+                2
+            )
+            ELSE NULL
+        END AS amount_usd_unadj,
+        _id,
+        t0._inserted_timestamp
+    FROM
+        {{ this }}
+        t0
+        LEFT JOIN {{ ref('silver__contracts') }} C
+        ON t0.token_address = C.contract_address
+        LEFT JOIN {{ ref('price__ez_prices_hourly') }}
+        p
+        ON t0.token_address = p.token_address
+        AND DATE_TRUNC(
+            'hour',
+            block_timestamp
+        ) = p.hour
+        LEFT JOIN {{ source(
+            'external_gold_defillama',
+            'dim_chains'
+        ) }}
+        d
+        ON d.chain_id :: STRING = t0.destination_chain_id :: STRING
+        OR LOWER(
+            d.chain
+        ) = LOWER(
+            t0.destination_chain
+        )
+    WHERE
+        CONCAT(
+            t0.block_number,
+            '-',
+            t0.platform,
+            '-',
+            t0.version
+        ) IN (
+            SELECT
+                CONCAT(
+                    t1.block_number,
+                    '-',
+                    t1.platform,
+                    '-',
+                    t1.version
+                )
+            FROM
+                {{ this }}
+                t1
+            WHERE
+                t1.token_decimals IS NULL
+                AND t1._inserted_timestamp < (
+                    SELECT
+                        MAX(
+                            _inserted_timestamp
+                        ) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
+                    FROM
+                        {{ this }}
+                )
+                AND EXISTS (
+                    SELECT
+                        1
+                    FROM
+                        {{ ref('silver__contracts') }} C
+                    WHERE
+                        C._inserted_timestamp > DATEADD('DAY', -14, SYSDATE())
+                        AND C.token_decimals IS NOT NULL
+                        AND C.contract_address = t1.token_address)
+                    GROUP BY
+                        1
+                )
+                OR CONCAT(
+                    t0.block_number,
+                    '-',
+                    t0.platform,
+                    '-',
+                    t0.version
+                ) IN (
+                    SELECT
+                        CONCAT(
+                            t2.block_number,
+                            '-',
+                            t2.platform,
+                            '-',
+                            t2.version
+                        )
+                    FROM
+                        {{ this }}
+                        t2
+                    WHERE
+                        t2.amount_usd IS NULL
+                        AND t2._inserted_timestamp < (
+                            SELECT
+                                MAX(
+                                    _inserted_timestamp
+                                ) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
+                            FROM
+                                {{ this }}
+                        )
+                        AND EXISTS (
+                            SELECT
+                                1
+                            FROM
+                                {{ ref('silver__complete_token_prices') }}
+                                p
+                            WHERE
+                                p._inserted_timestamp > DATEADD('DAY', -14, SYSDATE())
+                                AND p.price IS NOT NULL
+                                AND p.token_address = t2.token_address
+                                AND p.hour = DATE_TRUNC(
+                                    'hour',
+                                    t2.block_timestamp
+                                )
+                        )
+                    GROUP BY
+                        1
+                )
+        ),
+    {% endif %}
+
+    FINAL AS (
+        SELECT
+            *
+        FROM
+            complete_bridge_activity
+
+{% if is_incremental() and var(
+    'HEAL_MODEL'
+) %}
+UNION ALL
+SELECT
+    *
+FROM
+    heal_model
+{% endif %}
 )
 SELECT
     block_number,
@@ -688,21 +879,18 @@ SELECT
     token_decimals,
     amount_unadj,
     amount,
-    CASE
-        WHEN amount_usd_unadj < 1e+15 THEN amount_usd_unadj
-        ELSE NULL
-    END AS amount_usd,
+    amount_usd,
     _id,
     _inserted_timestamp,
     {{ dbt_utils.generate_surrogate_key(
-    ['_id']
+        ['_id']
     ) }} AS complete_bridge_activity_id,
     SYSDATE() AS inserted_timestamp,
     SYSDATE() AS modified_timestamp,
     '{{ invocation_id }}' AS _invocation_id
 FROM
-    FINAL 
-WHERE destination_chain <> 'arbitrum'
-qualify (ROW_NUMBER() over (PARTITION BY _id
+    FINAL
+WHERE
+    destination_chain <> 'arbitrum' qualify (ROW_NUMBER() over (PARTITION BY _id
 ORDER BY
     _inserted_timestamp DESC)) = 1

--- a/models/silver/defi/bridge/silver_bridge__complete_bridge_activity.sql
+++ b/models/silver/defi/bridge/silver_bridge__complete_bridge_activity.sql
@@ -639,7 +639,7 @@ complete_bridge_activity AS (
                 2
             )
             ELSE NULL
-        END AS amount_usd_unadj,
+        END AS amount_usd,
         _id,
         b._inserted_timestamp
     FROM

--- a/models/silver/defi/bridge/silver_bridge__complete_bridge_activity.sql
+++ b/models/silver/defi/bridge/silver_bridge__complete_bridge_activity.sql
@@ -685,47 +685,20 @@ heal_model AS (
         sender,
         receiver,
         destination_chain_receiver,
-        CASE
-            WHEN platform IN (
-                'stargate',
-                'wormhole',
-                'meson'
-            ) THEN destination_chain_id :: STRING
-            WHEN d.chain_id IS NULL THEN destination_chain_id :: STRING
-            ELSE d.chain_id :: STRING
-        END AS destination_chain_id,
-        CASE
-            WHEN platform IN (
-                'stargate',
-                'wormhole',
-                'meson'
-            ) THEN LOWER(destination_chain)
-            WHEN d.chain IS NULL THEN LOWER(destination_chain)
-            ELSE LOWER(
-                d.chain
-            )
-        END AS destination_chain,
+        destination_chain_id,
+        destination_chain,
         t0.token_address,
-        CASE
-            WHEN platform = 'axelar' THEN COALESCE(
-                C.token_symbol,
-                t0.token_symbol
-            )
-            ELSE C.token_symbol
-        END AS token_symbol,
+        C.token_symbol AS token_symbol,
         C.token_decimals AS token_decimals,
         amount_unadj,
         CASE
             WHEN C.token_decimals IS NOT NULL THEN (amount_unadj / pow(10, C.token_decimals))
             ELSE amount_unadj
-        END AS amount,
+        END AS amount_heal,
         CASE
-            WHEN C.token_decimals IS NOT NULL THEN ROUND(
-                amount * p.price,
-                2
-            )
+            WHEN C.token_decimals IS NOT NULL THEN amount_heal * p.price
             ELSE NULL
-        END AS amount_usd_unadj,
+        END AS amount_usd_heal,
         _id,
         t0._inserted_timestamp
     FROM
@@ -740,17 +713,6 @@ heal_model AS (
             'hour',
             block_timestamp
         ) = p.hour
-        LEFT JOIN {{ source(
-            'external_gold_defillama',
-            'dim_chains'
-        ) }}
-        d
-        ON d.chain_id :: STRING = t0.destination_chain_id :: STRING
-        OR LOWER(
-            d.chain
-        ) = LOWER(
-            t0.destination_chain
-        )
     WHERE
         CONCAT(
             t0.block_number,
@@ -852,7 +814,30 @@ heal_model AS (
 ) %}
 UNION ALL
 SELECT
-    *
+    block_number,
+    block_timestamp,
+    origin_from_address,
+    origin_to_address,
+    origin_function_signature,
+    tx_hash,
+    event_index,
+    bridge_address,
+    event_name,
+    platform,
+    version,
+    sender,
+    receiver,
+    destination_chain_receiver,
+    destination_chain_id,
+    destination_chain,
+    token_address,
+    token_symbol,
+    token_decimals,
+    amount_unadj,
+    amount_heal AS amount,
+    amount_usd_heal AS amount_usd,
+    _id,
+    _inserted_timestamp
 FROM
     heal_model
 {% endif %}

--- a/models/silver/defi/bridge/silver_bridge__complete_bridge_activity.sql
+++ b/models/silver/defi/bridge/silver_bridge__complete_bridge_activity.sql
@@ -1,9 +1,10 @@
+-- depends_on: {{ ref('silver__complete_token_prices') }}
 {{ config(
     materialized = 'incremental',
     incremental_strategy = 'delete+insert',
     unique_key = ['block_number','platform','version'],
     cluster_by = ['block_timestamp::DATE'],
-    tags = ['curated','reorg']
+    tags = ['curated','reorg','heal']
 ) }}
 
 WITH across AS (
@@ -33,11 +34,11 @@ WITH across AS (
     FROM
         {{ ref('silver_bridge__across_fundsdeposited') }}
 
-{% if is_incremental() and 'across' not in var('HEAL_CURATED_MODEL') %}
+{% if is_incremental() and 'across' not in var('HEAL_MODELS') %}
 WHERE
     _inserted_timestamp >= (
         SELECT
-            MAX(_inserted_timestamp) - INTERVAL '36 hours'
+            MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
         FROM
             {{ this }}
     )
@@ -70,11 +71,11 @@ across_v3 AS (
     FROM
         {{ ref('silver_bridge__across_v3fundsdeposited') }}
 
-{% if is_incremental() and 'across_v3' not in var('HEAL_CURATED_MODEL') %}
+{% if is_incremental() and 'across_v3' not in var('HEAL_MODELS') %}
 WHERE
     _inserted_timestamp >= (
         SELECT
-            MAX(_inserted_timestamp) - INTERVAL '36 hours'
+            MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
         FROM
             {{ this }}
     )
@@ -106,11 +107,11 @@ axelar AS (
     FROM
         {{ ref('silver_bridge__axelar_contractcallwithtoken') }}
 
-{% if is_incremental() and 'axelar' not in var('HEAL_CURATED_MODEL') %}
+{% if is_incremental() and 'axelar' not in var('HEAL_MODELS') %}
 WHERE
     _inserted_timestamp >= (
         SELECT
-            MAX(_inserted_timestamp) - INTERVAL '36 hours'
+            MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
         FROM
             {{ this }}
     )
@@ -142,11 +143,11 @@ celer_cbridge AS (
     FROM
         {{ ref('silver_bridge__celer_cbridge_send') }}
 
-{% if is_incremental() and 'celer_cbridge' not in var('HEAL_CURATED_MODEL') %}
+{% if is_incremental() and 'celer_cbridge' not in var('HEAL_MODELS') %}
 WHERE
     _inserted_timestamp >= (
         SELECT
-            MAX(_inserted_timestamp) - INTERVAL '36 hours'
+            MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
         FROM
             {{ this }}
     )
@@ -178,11 +179,11 @@ dln_debridge AS (
     FROM
         {{ ref('silver_bridge__dln_debridge_createdorder') }}
 
-{% if is_incremental() and 'dln_debridge' not in var('HEAL_CURATED_MODEL') %}
+{% if is_incremental() and 'dln_debridge' not in var('HEAL_MODELS') %}
 WHERE
     _inserted_timestamp >= (
         SELECT
-            MAX(_inserted_timestamp) - INTERVAL '36 hours'
+            MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
         FROM
             {{ this }}
     )
@@ -214,11 +215,11 @@ eywa AS (
     FROM
         {{ ref('silver_bridge__eywa_requestsent') }}
 
-{% if is_incremental() and 'eywa' not in var('HEAL_CURATED_MODEL') %}
+{% if is_incremental() and 'eywa' not in var('HEAL_MODELS') %}
 WHERE
     _inserted_timestamp >= (
         SELECT
-            MAX(_inserted_timestamp) - INTERVAL '36 hours'
+            MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
         FROM
             {{ this }}
     )
@@ -250,11 +251,11 @@ hop AS (
     FROM
         {{ ref('silver_bridge__hop_transfersent') }}
 
-{% if is_incremental() and 'hop' not in var('HEAL_CURATED_MODEL') %}
+{% if is_incremental() and 'hop' not in var('HEAL_MODELS') %}
 WHERE
     _inserted_timestamp >= (
         SELECT
-            MAX(_inserted_timestamp) - INTERVAL '36 hours'
+            MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
         FROM
             {{ this }}
     )
@@ -286,11 +287,11 @@ meson AS (
     FROM
         {{ ref('silver_bridge__meson_transfers') }}
 
-{% if is_incremental() and 'meson' not in var('HEAL_CURATED_MODEL') %}
+{% if is_incremental() and 'meson' not in var('HEAL_MODELS') %}
 WHERE
     _inserted_timestamp >= (
         SELECT
-            MAX(_inserted_timestamp) - INTERVAL '36 hours'
+            MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
         FROM
             {{ this }}
     )
@@ -322,11 +323,11 @@ multichain AS (
     FROM
         {{ ref('silver_bridge__multichain_v7_loganyswapout') }}
 
-{% if is_incremental() and 'multichain' not in var('HEAL_CURATED_MODEL') %}
+{% if is_incremental() and 'multichain' not in var('HEAL_MODELS') %}
 WHERE
     _inserted_timestamp >= (
         SELECT
-            MAX(_inserted_timestamp) - INTERVAL '36 hours'
+            MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
         FROM
             {{ this }}
     )
@@ -358,11 +359,11 @@ stargate AS (
     FROM
         {{ ref('silver_bridge__stargate_swap') }}
 
-{% if is_incremental() and 'stargate' not in var('HEAL_CURATED_MODEL') %}
+{% if is_incremental() and 'stargate' not in var('HEAL_MODELS') %}
 WHERE
     _inserted_timestamp >= (
         SELECT
-            MAX(_inserted_timestamp) - INTERVAL '36 hours'
+            MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
         FROM
             {{ this }}
     )
@@ -394,11 +395,11 @@ symbiosis AS (
     FROM
         {{ ref('silver_bridge__symbiosis_synthesizerequest') }}
 
-{% if is_incremental() and 'symbiosis' not in var('HEAL_CURATED_MODEL') %}
+{% if is_incremental() and 'symbiosis' not in var('HEAL_MODELS') %}
 WHERE
     _inserted_timestamp >= (
         SELECT
-            MAX(_inserted_timestamp) - INTERVAL '36 hours'
+            MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
         FROM
             {{ this }}
     )
@@ -430,11 +431,11 @@ synapse_tb AS (
     FROM
         {{ ref('silver_bridge__synapse_token_bridge') }}
 
-{% if is_incremental() and 'synapse_tb' not in var('HEAL_CURATED_MODEL') %}
+{% if is_incremental() and 'synapse_tb' not in var('HEAL_MODELS') %}
 WHERE
     _inserted_timestamp >= (
         SELECT
-            MAX(_inserted_timestamp) - INTERVAL '36 hours'
+            MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
         FROM
             {{ this }}
     )
@@ -466,11 +467,11 @@ synapse_tbs AS (
     FROM
         {{ ref('silver_bridge__synapse_tokenbridgeandswap') }}
 
-{% if is_incremental() and 'synapse_tbs' not in var('HEAL_CURATED_MODEL') %}
+{% if is_incremental() and 'synapse_tbs' not in var('HEAL_MODELS') %}
 WHERE
     _inserted_timestamp >= (
         SELECT
-            MAX(_inserted_timestamp) - INTERVAL '36 hours'
+            MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
         FROM
             {{ this }}
     )
@@ -502,11 +503,11 @@ wormhole AS (
     FROM
         {{ ref('silver_bridge__wormhole_transfers') }}
 
-{% if is_incremental() and 'wormhole' not in var('HEAL_CURATED_MODEL') %}
+{% if is_incremental() and 'wormhole' not in var('HEAL_MODELS') %}
 WHERE
     _inserted_timestamp >= (
         SELECT
-            MAX(_inserted_timestamp) - INTERVAL '36 hours'
+            MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
         FROM
             {{ this }}
     )

--- a/models/silver/defi/bridge/stargate/silver_bridge__stargate_createpool.sql
+++ b/models/silver/defi/bridge/stargate/silver_bridge__stargate_createpool.sql
@@ -20,7 +20,8 @@ WITH base_contracts AS (
     WHERE
         from_address = '0x55bdb4164d28fbaf0898e0ef14a589ac09ac9970'
         AND TYPE ILIKE 'create%'
-        AND tx_status ILIKE 'success'
+        AND tx_status = 'SUCCESS'
+        AND trace_status = 'SUCCESS'
 
 {% if is_incremental() %}
 AND _inserted_timestamp >= (

--- a/models/silver/defi/bridge/stargate/silver_bridge__stargate_swap.sql
+++ b/models/silver/defi/bridge/stargate/silver_bridge__stargate_swap.sql
@@ -66,6 +66,7 @@ base_evt AS (
         ON d.contract_address = p.pool_address
     WHERE
         topics [0] :: STRING = '0x34660fc8af304464529f48a778e03d03e4d34bcd5f9b6f0cfbf3cd238c642f7f'
+        AND tx_status = 'SUCCESS'
 
 {% if is_incremental() %}
 AND _inserted_timestamp >= (

--- a/models/silver/defi/bridge/symbiosis/silver_bridge__symbiosis_synthesizerequest.sql
+++ b/models/silver/defi/bridge/symbiosis/silver_bridge__symbiosis_synthesizerequest.sql
@@ -44,6 +44,7 @@ WITH base_evt AS (
             '0x0425841529882628880fbd228ac90606e0c2e09a',
             '0x01a3c8e513b758ebb011f7afaf6c37616c9c24d9'
         )
+        AND tx_status = 'SUCCESS'
 
 {% if is_incremental() %}
 AND _inserted_timestamp >= (

--- a/models/silver/defi/bridge/synapse/silver_bridge__synapse_token_bridge.sql
+++ b/models/silver/defi/bridge/synapse/silver_bridge__synapse_token_bridge.sql
@@ -43,6 +43,7 @@ WITH base_evt AS (
         )
         AND contract_address = '0x6f4e8eba4d337f874ab57478acc2cb5bacdc19c9'
         AND origin_to_address IS NOT NULL
+        AND tx_status = 'SUCCESS'
 
 {% if is_incremental() %}
 AND _inserted_timestamp >= (

--- a/models/silver/defi/bridge/synapse/silver_bridge__synapse_tokenbridgeandswap.sql
+++ b/models/silver/defi/bridge/synapse/silver_bridge__synapse_tokenbridgeandswap.sql
@@ -50,6 +50,7 @@ WITH base_evt AS (
     WHERE
         topics [0] :: STRING = '0x91f25e9be0134ec851830e0e76dc71e06f9dade75a9b84e9524071dbbc319425'
         AND contract_address = '0x6f4e8eba4d337f874ab57478acc2cb5bacdc19c9'
+        AND tx_status = 'SUCCESS'
 
 {% if is_incremental() %}
 AND _inserted_timestamp >= (

--- a/models/silver/defi/dex/balancer/silver_dex__balancer_pools.sql
+++ b/models/silver/defi/dex/balancer/silver_dex__balancer_pools.sql
@@ -31,6 +31,7 @@ WITH pools_registered AS (
     WHERE
         topics [0] :: STRING = '0x3c13bc30b8e878c53fd2a36b679409c073afd75950be43d8858768e956fbc20e' --PoolRegistered
         AND contract_address = '0xba12222222228d8ba445958a75a0704d566bf2c8'
+        AND tx_status = 'SUCCESS'
 
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
@@ -72,6 +73,7 @@ tokens_registered AS (
             FROM
                 pools_registered
         )
+        AND tx_status = 'SUCCESS'
 ),
 function_sigs AS (
     SELECT

--- a/models/silver/defi/dex/balancer/silver_dex__balancer_swaps.sql
+++ b/models/silver/defi/dex/balancer/silver_dex__balancer_swaps.sql
@@ -54,6 +54,7 @@ swaps_base AS (
     WHERE
         topics [0] :: STRING = '0x2170c741c41531aec20e7c107c24eecfdd15e69c9bb0a8dd37b1840b9e0b207b'
         AND contract_address = '0xba12222222228d8ba445958a75a0704d566bf2c8'
+        AND tx_status = 'SUCCESS'
 
 {% if is_incremental() %}
 AND _inserted_timestamp >= (

--- a/models/silver/defi/dex/camelot/silver_dex__camelot_pools.sql
+++ b/models/silver/defi/dex/camelot/silver_dex__camelot_pools.sql
@@ -33,6 +33,7 @@ WITH pool_creation AS (
             --PairCreated v2
             '0x91ccaa7a278130b65168c3a0c8d3bcae84cf5e43704342bd3ec0b59e59c036db'
         ) --v3
+        AND tx_status = 'SUCCESS'
 
 {% if is_incremental() %}
 AND _inserted_timestamp >= (

--- a/models/silver/defi/dex/curve/silver_dex__curve_pools.sql
+++ b/models/silver/defi/dex/curve/silver_dex__curve_pools.sql
@@ -33,8 +33,8 @@ WITH contract_deployments AS (
             '0xb17b674d9c5cb2e441f8e196a2f048a81355d031'
         )
         AND TYPE ILIKE 'create%'
-        AND tx_status ILIKE 'SUCCESS'
-        AND trace_status ILIKE 'SUCCESS'
+        AND tx_status = 'SUCCESS'
+        AND trace_status = 'SUCCESS'
 
 {% if is_incremental() %}
 AND _inserted_timestamp >= (

--- a/models/silver/defi/dex/curve/silver_dex__curve_swaps.sql
+++ b/models/silver/defi/dex/curve/silver_dex__curve_swaps.sql
@@ -69,6 +69,7 @@ curve_base AS (
             '0xb2e76ae99761dc136e598d4a629bb347eccb9532a5f8bbd72e18467c3c34cc98',
             '0xd013ca23e77a65003c2c659c5442c00c805371b7fc1ebd4c206c41d1536bd90b'
         )
+        AND tx_status = 'SUCCESS'
 
 {% if is_incremental() %}
 AND _inserted_timestamp >= (

--- a/models/silver/defi/dex/dodo/silver_dex__dodo_v1_pools.sql
+++ b/models/silver/defi/dex/dodo/silver_dex__dodo_v1_pools.sql
@@ -24,6 +24,7 @@ WITH pool_events AS (
     WHERE
         contract_address = '0xbcc3401e16c25eaf4d3fed632ce3288503883b1f' --DODOZoo
         AND topics [0] :: STRING = '0x5c428a2e12ecaa744a080b25b4cda8b86359c82d726575d7d747e07708071f93' --DODOBirth
+        AND tx_status = 'SUCCESS'
 
 {% if is_incremental() %}
 AND _inserted_timestamp >= (

--- a/models/silver/defi/dex/dodo/silver_dex__dodo_v1_swaps.sql
+++ b/models/silver/defi/dex/dodo/silver_dex__dodo_v1_swaps.sql
@@ -64,6 +64,7 @@ sell_base_token AS (
             FROM
                 proxies
         )
+        AND tx_status = 'SUCCESS'
 
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
@@ -117,6 +118,7 @@ buy_base_token AS (
             FROM
                 proxies
         )
+        AND tx_status = 'SUCCESS'
 
 {% if is_incremental() %}
 AND _inserted_timestamp >= (

--- a/models/silver/defi/dex/dodo/silver_dex__dodo_v2_pools.sql
+++ b/models/silver/defi/dex/dodo/silver_dex__dodo_v2_pools.sql
@@ -42,6 +42,7 @@ WITH pools AS (
             --NewDSP
             '0xaf5c5f12a80fc937520df6fcaed66262a4cc775e0f3fceaf7a7cfe476d9a751d' --NewDVM
         )
+        AND tx_status = 'SUCCESS'
 
 {% if is_incremental() %}
 AND _inserted_timestamp >= (

--- a/models/silver/defi/dex/dodo/silver_dex__dodo_v2_swaps.sql
+++ b/models/silver/defi/dex/dodo/silver_dex__dodo_v2_swaps.sql
@@ -89,6 +89,7 @@ swaps_base AS (
             FROM
                 proxies
         )
+        AND tx_status = 'SUCCESS'
 
 {% if is_incremental() %}
 AND _inserted_timestamp >= (

--- a/models/silver/defi/dex/fraxswap/silver_dex__fraxswap_pools.sql
+++ b/models/silver/defi/dex/fraxswap/silver_dex__fraxswap_pools.sql
@@ -31,6 +31,7 @@ WITH pool_creation AS (
             '0x8374a74a728f06bea6b7259c68aa7bbb732bfead' --v2 factory
         )
         AND topics [0] :: STRING = '0x0d3648bd0f6ba80134a33ba9275ac585d9d315f0ad8355cddefde31afa28d0e9' --pairCreated
+        AND tx_status = 'SUCCESS'
 
 {% if is_incremental() %}
 AND _inserted_timestamp >= (

--- a/models/silver/defi/dex/fraxswap/silver_dex__fraxswap_swaps.sql
+++ b/models/silver/defi/dex/fraxswap/silver_dex__fraxswap_swaps.sql
@@ -59,6 +59,7 @@ swaps_base AS (
         ON l.contract_address = pool_address
     WHERE
         l.topics [0] :: STRING = '0xd78ad95fa46c994b6551d0da85fc275fe613ce37657fb8d5e3d130840159d822' --Swap
+        AND tx_status = 'SUCCESS'
 
 {% if is_incremental() %}
 AND _inserted_timestamp >= (

--- a/models/silver/defi/dex/gmx/silver_dex__gmx_swaps.sql
+++ b/models/silver/defi/dex/gmx/silver_dex__gmx_swaps.sql
@@ -69,6 +69,7 @@ WITH swaps_base AS (
     WHERE
         contract_address = '0x489ee077994b6658eafa855c308275ead8097c4a'
         AND topics [0] :: STRING = '0x0874b2d545cb271cdbda4e093020c452328b24af12382ed62c4d00f5c26709db'
+        AND tx_status = 'SUCCESS'
 
 {% if is_incremental() %}
 AND _inserted_timestamp >= (

--- a/models/silver/defi/dex/hashflow/silver_dex__hashflow_pools.sql
+++ b/models/silver/defi/dex/hashflow/silver_dex__hashflow_pools.sql
@@ -24,7 +24,8 @@ WITH contract_deployments AS (
             '0x75fb2ab4d5b0de8b1a1acdc9124887d35d459084'
         )
         AND TYPE ILIKE 'create%'
-        AND tx_status ILIKE 'success'
+        AND tx_status = 'SUCCESS'
+        AND trace_status = 'SUCCESS'
 
 {% if is_incremental() %}
 AND _inserted_timestamp >= (

--- a/models/silver/defi/dex/hashflow/silver_dex__hashflow_swaps.sql
+++ b/models/silver/defi/dex/hashflow/silver_dex__hashflow_swaps.sql
@@ -67,6 +67,7 @@ router_swaps_base AS (
         ON l.contract_address = p.pool_address
     WHERE
         l.topics [0] :: STRING = '0xb709ddcc6550418e9b89df1f4938071eeaa3f6376309904c77e15d46b16066f5' --swap
+        AND tx_status = 'SUCCESS'
 
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
@@ -131,6 +132,7 @@ swaps_base AS (
         ON l.contract_address = p.pool_address
     WHERE
         l.topics [0] :: STRING = '0x8cf3dec1929508e5677d7db003124e74802bfba7250a572205a9986d86ca9f1e' --swap
+        AND tx_status = 'SUCCESS'
 
 {% if is_incremental() %}
 AND _inserted_timestamp >= (

--- a/models/silver/defi/dex/hashflow/silver_dex__hashflow_v3_pools.sql
+++ b/models/silver/defi/dex/hashflow/silver_dex__hashflow_v3_pools.sql
@@ -21,6 +21,7 @@ WITH contract_deployments AS (
     WHERE
         contract_address = LOWER('0xdE828fdc3F497F16416D1bB645261C7C6a62DAb5')
         AND topics [0] :: STRING = '0xdbd2a1ea6808362e6adbec4db4969cbc11e3b0b28fb6c74cb342defaaf1daada'
+        AND tx_status = 'SUCCESS'
 
 {% if is_incremental() %}
 AND _inserted_timestamp >= (

--- a/models/silver/defi/dex/hashflow/silver_dex__hashflow_v3_swaps.sql
+++ b/models/silver/defi/dex/hashflow/silver_dex__hashflow_v3_swaps.sql
@@ -51,6 +51,7 @@ swaps AS (
         ON l.contract_address = p.pool_address
     WHERE
         l.topics [0] :: STRING = '0x34f57786fb01682fb4eec88d340387ef01a168fe345ea5b76f709d4e560c10eb' --Trade
+        AND tx_status = 'SUCCESS'
 
 {% if is_incremental() %}
 AND _inserted_timestamp >= (

--- a/models/silver/defi/dex/kyberswap/silver_dex__kyberswap_v1_dynamic_pools.sql
+++ b/models/silver/defi/dex/kyberswap/silver_dex__kyberswap_v1_dynamic_pools.sql
@@ -34,6 +34,7 @@ WITH pool_creation AS (
     WHERE
         contract_address = LOWER('0xD9bfE9979e9CA4b2fe84bA5d4Cf963bBcB376974') --dynamic fee factory
         AND topics [0] :: STRING = '0xfc574402c445e75f2b79b67884ff9c662244dce454c5ae68935fcd0bebb7c8ff' --created pool
+        AND tx_status = 'SUCCESS'
 
 {% if is_incremental() %}
 AND _inserted_timestamp >= (

--- a/models/silver/defi/dex/kyberswap/silver_dex__kyberswap_v1_dynamic_swaps.sql
+++ b/models/silver/defi/dex/kyberswap/silver_dex__kyberswap_v1_dynamic_swaps.sql
@@ -64,6 +64,7 @@ swaps_base AS (
         ON p.pool_address = l.contract_address
     WHERE
         l.topics [0] :: STRING = '0x606ecd02b3e3b4778f8e97b2e03351de14224efaa5fa64e62200afc9395c2499' --Dynamic Swap
+        AND tx_status = 'SUCCESS'
 
 {% if is_incremental() %}
 AND _inserted_timestamp >= (

--- a/models/silver/defi/dex/kyberswap/silver_dex__kyberswap_v1_static_pools.sql
+++ b/models/silver/defi/dex/kyberswap/silver_dex__kyberswap_v1_static_pools.sql
@@ -39,6 +39,7 @@ WITH pool_creation AS (
     WHERE
         contract_address = LOWER('0x1c758aF0688502e49140230F6b0EBd376d429be5') --static pool factory
         AND topics [0] :: STRING = '0xb6bce363b712c921bead4bcc977289440eb6172eb89e258e3a25bd49ca806de6' --create pool
+        AND tx_status = 'SUCCESS'
 
 {% if is_incremental() %}
 AND _inserted_timestamp >= (

--- a/models/silver/defi/dex/kyberswap/silver_dex__kyberswap_v1_static_swaps.sql
+++ b/models/silver/defi/dex/kyberswap/silver_dex__kyberswap_v1_static_swaps.sql
@@ -64,6 +64,7 @@ swaps_base AS (
         ON p.pool_address = l.contract_address
     WHERE
         l.topics [0] :: STRING = '0x606ecd02b3e3b4778f8e97b2e03351de14224efaa5fa64e62200afc9395c2499' -- static swap
+        AND tx_status = 'SUCCESS'
 
 {% if is_incremental() %}
 AND _inserted_timestamp >= (

--- a/models/silver/defi/dex/kyberswap/silver_dex__kyberswap_v2_elastic_pools.sql
+++ b/models/silver/defi/dex/kyberswap/silver_dex__kyberswap_v2_elastic_pools.sql
@@ -33,6 +33,7 @@ WITH pool_creation AS (
             '0xc7a590291e07b9fe9e64b86c58fd8fc764308c4a'
         ) --KyberSwap: Elastic Factory
         AND topics [0] :: STRING = '0x783cca1c0412dd0d695e784568c96da2e9c22ff989357a2e8b1d9b2b4e6b7118' --Create pool
+        AND tx_status = 'SUCCESS'
 
 {% if is_incremental() %}
 AND _inserted_timestamp >= (

--- a/models/silver/defi/dex/kyberswap/silver_dex__kyberswap_v2_elastic_swaps.sql
+++ b/models/silver/defi/dex/kyberswap/silver_dex__kyberswap_v2_elastic_swaps.sql
@@ -77,6 +77,7 @@ swaps_base AS (
         ON p.pool_address = l.contract_address
     WHERE
         topics [0] :: STRING = '0xc42079f94a6350d7e6235f29174924f928cc2ac818eb64fed8004e115fbcca67' -- elastic swap
+        AND tx_status = 'SUCCESS'
 
 {% if is_incremental() %}
 AND _inserted_timestamp >= (

--- a/models/silver/defi/dex/ramses/silver_dex__ramses_v2_pools.sql
+++ b/models/silver/defi/dex/ramses/silver_dex__ramses_v2_pools.sql
@@ -32,6 +32,7 @@ WITH created_pools AS (
     WHERE
         topics [0] = '0x783cca1c0412dd0d695e784568c96da2e9c22ff989357a2e8b1d9b2b4e6b7118'
         AND contract_address = lower('0xAA2cd7477c451E703f3B9Ba5663334914763edF8')
+        AND tx_status = 'SUCCESS'
 
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
@@ -58,6 +59,7 @@ initial_info AS (
         {{ ref('silver__logs') }}
     WHERE
         topics [0] :: STRING = '0x98636036cb66a9c19a37435efc1e90142190214e8abeb821bdba3f2990dd4c95'
+        AND tx_status = 'SUCCESS'
 
 {% if is_incremental() %}
 AND _inserted_timestamp >= (

--- a/models/silver/defi/dex/silver_dex__complete_dex_liquidity_pools.sql
+++ b/models/silver/defi/dex/silver_dex__complete_dex_liquidity_pools.sql
@@ -996,7 +996,7 @@ heal_model AS (
           CONCAT(SUBSTRING(token1, 1, 5), '...', SUBSTRING(token1, 39, 42))
         )
       )
-    END AS pool_name,
+    END AS pool_name_heal,
     fee,
     tick_spacing,
     token0,
@@ -1007,24 +1007,7 @@ heal_model AS (
     token5,
     token6,
     token7,
-    OBJECT_CONSTRUCT(
-      'token0',
-      token0,
-      'token1',
-      token1,
-      'token2',
-      token2,
-      'token3',
-      token3,
-      'token4',
-      token4,
-      'token5',
-      token5,
-      'token6',
-      token6,
-      'token7',
-      token7
-    ) AS tokens,
+    tokens,
     OBJECT_CONSTRUCT(
       'token0',
       c0.token_symbol,
@@ -1042,7 +1025,7 @@ heal_model AS (
       c6.token_symbol,
       'token7',
       c7.token_symbol
-    ) AS symbols,
+    ) AS symbols_heal,
     OBJECT_CONSTRUCT(
       'token0',
       c0.token_decimals,
@@ -1060,7 +1043,7 @@ heal_model AS (
       c6.token_decimals,
       'token7',
       c7.token_decimals
-    ) AS decimals,
+    ) AS decimals_heal,
     platform,
     version,
     _id,
@@ -1419,7 +1402,29 @@ heal_model AS (
 ) %}
 UNION ALL
 SELECT
-  *
+  block_number,
+  block_timestamp,
+  tx_hash,
+  contract_address,
+  pool_address,
+  pool_name_heal AS pool_name,
+  fee,
+  tick_spacing,
+  token0,
+  token1,
+  token2,
+  token3,
+  token4,
+  token5,
+  token6,
+  token7,
+  tokens,
+  symbols_heal AS symbols,
+  decimals_heal AS decimals,
+  platform,
+  version,
+  _id,
+  _inserted_timestamp
 FROM
   heal_model
 {% endif %}

--- a/models/silver/defi/dex/silver_dex__complete_dex_liquidity_pools.sql
+++ b/models/silver/defi/dex/silver_dex__complete_dex_liquidity_pools.sql
@@ -3,7 +3,7 @@
   incremental_strategy = 'delete+insert',
   unique_key = ['block_number','platform','version'],
   cluster_by = ['block_timestamp::DATE'],
-  tags = ['curated','reorg']
+  tags = ['curated','reorg','heal']
 ) }}
 
 WITH contracts AS (
@@ -41,11 +41,11 @@ SELECT
 FROM
     {{ ref('silver_dex__balancer_pools') }}
 
-{% if is_incremental() and 'balancer' not in var('HEAL_CURATED_MODEL') %}
+{% if is_incremental() and 'balancer' not in var('HEAL_MODELS') %}
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) - INTERVAL '12 hours'
+      MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
     FROM
       {{ this }}
   )
@@ -75,11 +75,11 @@ SELECT
     MAX(CASE WHEN token_num = 8 THEN token_address END) AS token7
 FROM
     {{ ref('silver_dex__curve_pools') }}
-{% if is_incremental() and 'curve' not in var('HEAL_CURATED_MODEL') %}
+{% if is_incremental() and 'curve' not in var('HEAL_MODELS') %}
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) - INTERVAL '12 hours'
+      MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
     FROM
       {{ this }}
   )
@@ -104,11 +104,11 @@ SELECT
     _inserted_timestamp
 FROM
     {{ ref('silver_dex__camelot_pools') }}
-{% if is_incremental() and 'camelot' not in var('HEAL_CURATED_MODEL') %}
+{% if is_incremental() and 'camelot' not in var('HEAL_MODELS') %}
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) - INTERVAL '12 hours'
+      MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
     FROM
       {{ this }}
   )
@@ -132,11 +132,11 @@ SELECT
     _inserted_timestamp
 FROM 
     {{ ref('silver_dex__dodo_v1_pools') }}
-{% if is_incremental() and 'dodo_v1' not in var('HEAL_CURATED_MODEL') %}
+{% if is_incremental() and 'dodo_v1' not in var('HEAL_MODELS') %}
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) - INTERVAL '12 hours'
+      MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
     FROM
       {{ this }}
   )
@@ -161,11 +161,11 @@ SELECT
 FROM 
     {{ ref('silver_dex__dodo_v2_pools') }}
 WHERE token0 IS NOT NULL
-{% if is_incremental() and 'dodo_v2' not in var('HEAL_CURATED_MODEL') %}
+{% if is_incremental() and 'dodo_v2' not in var('HEAL_MODELS') %}
 AND
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) - INTERVAL '12 hours'
+      MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
     FROM
       {{ this }}
   )
@@ -189,11 +189,11 @@ SELECT
     _inserted_timestamp
 FROM
     {{ ref('silver_dex__fraxswap_pools') }}
-{% if is_incremental() and 'frax' not in var('HEAL_CURATED_MODEL') %}
+{% if is_incremental() and 'frax' not in var('HEAL_MODELS') %}
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) - INTERVAL '12 hours'
+      MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
     FROM
       {{ this }}
   )
@@ -217,11 +217,11 @@ SELECT
     _inserted_timestamp
 FROM
     {{ ref('silver_dex__kyberswap_v1_dynamic_pools') }}
-{% if is_incremental() and 'kyberswap_v1_dynamic' not in var('HEAL_CURATED_MODEL') %}
+{% if is_incremental() and 'kyberswap_v1_dynamic' not in var('HEAL_MODELS') %}
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) - INTERVAL '12 hours'
+      MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
     FROM
       {{ this }}
   )
@@ -245,11 +245,11 @@ SELECT
     _inserted_timestamp
 FROM
     {{ ref('silver_dex__kyberswap_v1_static_pools') }}
-{% if is_incremental() and 'kyberswap_v1_static' not in var('HEAL_CURATED_MODEL') %}
+{% if is_incremental() and 'kyberswap_v1_static' not in var('HEAL_MODELS') %}
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) - INTERVAL '12 hours'
+      MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
     FROM
       {{ this }}
   )
@@ -274,11 +274,11 @@ SELECT
     _inserted_timestamp
 FROM
     {{ ref('silver_dex__kyberswap_v2_elastic_pools') }}
-{% if is_incremental() and 'kyberswap_v2_elastic' not in var('HEAL_CURATED_MODEL') %}
+{% if is_incremental() and 'kyberswap_v2_elastic' not in var('HEAL_MODELS') %}
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) - INTERVAL '12 hours'
+      MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
     FROM
       {{ this }}
   )
@@ -302,11 +302,11 @@ SELECT
     _inserted_timestamp
 FROM
     {{ ref('silver_dex__sushi_pools') }}
-{% if is_incremental() and 'sushi' not in var('HEAL_CURATED_MODEL') %}
+{% if is_incremental() and 'sushi' not in var('HEAL_MODELS') %}
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) - INTERVAL '12 hours'
+      MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
     FROM
       {{ this }}
   )
@@ -330,11 +330,11 @@ SELECT
     _inserted_timestamp
 FROM
     {{ ref('silver_dex__trader_joe_v1_pools') }}
-{% if is_incremental() and 'trader_joe_v1' not in var('HEAL_CURATED_MODEL') %}
+{% if is_incremental() and 'trader_joe_v1' not in var('HEAL_MODELS') %}
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) - INTERVAL '12 hours'
+      MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
     FROM
       {{ this }}
   )
@@ -358,11 +358,11 @@ SELECT
     _inserted_timestamp
 FROM
     {{ ref('silver_dex__trader_joe_v2_pools') }}
-{% if is_incremental() and 'trader_joe_v2' not in var('HEAL_CURATED_MODEL') %}
+{% if is_incremental() and 'trader_joe_v2' not in var('HEAL_MODELS') %}
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) - INTERVAL '12 hours'
+      MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
     FROM
       {{ this }}
   )
@@ -386,11 +386,11 @@ SELECT
     _inserted_timestamp
 FROM
     {{ ref('silver_dex__zyberswap_pools') }}
-{% if is_incremental() and 'zyberswap' not in var('HEAL_CURATED_MODEL') %}
+{% if is_incremental() and 'zyberswap' not in var('HEAL_MODELS') %}
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) - INTERVAL '12 hours'
+      MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
     FROM
       {{ this }}
   )
@@ -415,11 +415,11 @@ SELECT
     _inserted_timestamp
 FROM
     {{ ref('silver_dex__ramses_v2_pools') }}
-{% if is_incremental() and 'ramses_v2' not in var('HEAL_CURATED_MODEL') %}
+{% if is_incremental() and 'ramses_v2' not in var('HEAL_MODELS') %}
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) - INTERVAL '12 hours'
+      MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
     FROM
       {{ this }}
   )
@@ -444,11 +444,11 @@ SELECT
     _inserted_timestamp
 FROM
     {{ ref('silver_dex__univ3_pools') }}
-{% if is_incremental() and 'uni_v3' not in var('HEAL_CURATED_MODEL') %}
+{% if is_incremental() and 'uni_v3' not in var('HEAL_MODELS') %}
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) - INTERVAL '12 hours'
+      MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
     FROM
       {{ this }}
   )
@@ -471,11 +471,11 @@ SELECT
     _inserted_timestamp
 FROM
     {{ ref('silver_dex__univ2_pools') }}
-{% if is_incremental() and 'uni_v2' not in var('HEAL_CURATED_MODEL') %}
+{% if is_incremental() and 'uni_v2' not in var('HEAL_MODELS') %}
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) - INTERVAL '12 hours'
+      MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
     FROM
       {{ this }}
   )
@@ -498,11 +498,11 @@ SELECT
     _inserted_timestamp
 FROM
     {{ ref('silver_dex__sparta_pools') }}
-{% if is_incremental() and 'sparta' not in var('HEAL_CURATED_MODEL') %}
+{% if is_incremental() and 'sparta' not in var('HEAL_MODELS') %}
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) - INTERVAL '12 hours'
+      MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
     FROM
       {{ this }}
   )

--- a/models/silver/defi/dex/silver_dex__complete_dex_liquidity_pools.sql
+++ b/models/silver/defi/dex/silver_dex__complete_dex_liquidity_pools.sql
@@ -9,9 +9,9 @@
 WITH contracts AS (
 
   SELECT
-    contract_address AS address,
-    token_symbol AS symbol,
-    token_decimals AS decimals,
+    contract_address,
+    token_symbol,
+    token_decimals,
     _inserted_timestamp
   FROM
     {{ ref('silver__contracts') }}

--- a/models/silver/defi/dex/silver_dex__complete_dex_liquidity_pools.sql
+++ b/models/silver/defi/dex/silver_dex__complete_dex_liquidity_pools.sql
@@ -16,20 +16,16 @@ WITH contracts AS (
   FROM
     {{ ref('silver__contracts') }}
 ),
-
 balancer AS (
-
-SELECT
+  SELECT
     block_number,
     block_timestamp,
     tx_hash,
     contract_address,
     pool_address,
     pool_name,
-    'balancer' AS platform,
-    'v1' AS version,
-    _log_id AS _id,
-    _inserted_timestamp,
+    NULL AS fee,
+    NULL AS tick_spacing,
     token0,
     token1,
     token2,
@@ -37,8 +33,12 @@ SELECT
     token4,
     token5,
     token6,
-    token7
-FROM
+    token7,
+    'balancer' AS platform,
+    'v1' AS version,
+    _log_id AS _id,
+    _inserted_timestamp
+  FROM
     {{ ref('silver_dex__balancer_pools') }}
 
 {% if is_incremental() and 'balancer' not in var('HEAL_MODELS') %}
@@ -51,30 +51,63 @@ WHERE
   )
 {% endif %}
 ),
-
 curve AS (
-
-SELECT
+  SELECT
     block_number,
     block_timestamp,
     tx_hash,
     deployer_address AS contract_address,
     pool_address,
     pool_name,
+    NULL AS fee,
+    NULL AS tick_spacing,
+    MAX(
+      CASE
+        WHEN token_num = 1 THEN token_address
+      END
+    ) AS token0,
+    MAX(
+      CASE
+        WHEN token_num = 2 THEN token_address
+      END
+    ) AS token1,
+    MAX(
+      CASE
+        WHEN token_num = 3 THEN token_address
+      END
+    ) AS token2,
+    MAX(
+      CASE
+        WHEN token_num = 4 THEN token_address
+      END
+    ) AS token3,
+    MAX(
+      CASE
+        WHEN token_num = 5 THEN token_address
+      END
+    ) AS token4,
+    MAX(
+      CASE
+        WHEN token_num = 6 THEN token_address
+      END
+    ) AS token5,
+    MAX(
+      CASE
+        WHEN token_num = 7 THEN token_address
+      END
+    ) AS token6,
+    MAX(
+      CASE
+        WHEN token_num = 8 THEN token_address
+      END
+    ) AS token7,
     'curve' AS platform,
     'v1' AS version,
     _call_id AS _id,
-    _inserted_timestamp,
-    MAX(CASE WHEN token_num = 1 THEN token_address END) AS token0,
-    MAX(CASE WHEN token_num = 2 THEN token_address END) AS token1,
-    MAX(CASE WHEN token_num = 3 THEN token_address END) AS token2,
-    MAX(CASE WHEN token_num = 4 THEN token_address END) AS token3,
-    MAX(CASE WHEN token_num = 5 THEN token_address END) AS token4,
-    MAX(CASE WHEN token_num = 6 THEN token_address END) AS token5,
-    MAX(CASE WHEN token_num = 7 THEN token_address END) AS token6,
-    MAX(CASE WHEN token_num = 8 THEN token_address END) AS token7
-FROM
+    _inserted_timestamp
+  FROM
     {{ ref('silver_dex__curve_pools') }}
+
 {% if is_incremental() and 'curve' not in var('HEAL_MODELS') %}
 WHERE
   _inserted_timestamp >= (
@@ -84,26 +117,34 @@ WHERE
       {{ this }}
   )
 {% endif %}
-GROUP BY all
+GROUP BY
+  ALL
 ),
-
 camelot AS (
-
-SELECT
+  SELECT
     block_number,
     block_timestamp,
     tx_hash,
     contract_address,
     pool_address,
     NULL AS pool_name,
+    NULL AS fee,
+    NULL AS tick_spacing,
     token0,
     token1,
+    NULL AS token2,
+    NULL AS token3,
+    NULL AS token4,
+    NULL AS token5,
+    NULL AS token6,
+    NULL AS token7,
     'camelot' AS platform,
     'v1' AS version,
     _log_id AS _id,
     _inserted_timestamp
-FROM
+  FROM
     {{ ref('silver_dex__camelot_pools') }}
+
 {% if is_incremental() and 'camelot' not in var('HEAL_MODELS') %}
 WHERE
   _inserted_timestamp >= (
@@ -114,24 +155,31 @@ WHERE
   )
 {% endif %}
 ),
-
 dodo_v1 AS (
-
-SELECT
+  SELECT
     block_number,
     block_timestamp,
     tx_hash,
     contract_address,
     pool_address,
     NULL AS pool_name,
+    NULL AS fee,
+    NULL AS tick_spacing,
     base_token AS token0,
     quote_token AS token1,
+    NULL AS token2,
+    NULL AS token3,
+    NULL AS token4,
+    NULL AS token5,
+    NULL AS token6,
+    NULL AS token7,
     'dodo-v1' AS platform,
     'v1' AS version,
     _id,
     _inserted_timestamp
-FROM 
+  FROM
     {{ ref('silver_dex__dodo_v1_pools') }}
+
 {% if is_incremental() and 'dodo_v1' not in var('HEAL_MODELS') %}
 WHERE
   _inserted_timestamp >= (
@@ -142,53 +190,67 @@ WHERE
   )
 {% endif %}
 ),
-
 dodo_v2 AS (
-
-SELECT
+  SELECT
     block_number,
     block_timestamp,
     tx_hash,
     contract_address,
     pool_address,
     NULL AS pool_name,
+    NULL AS fee,
+    NULL AS tick_spacing,
     base_token AS token0,
     quote_token AS token1,
+    NULL AS token2,
+    NULL AS token3,
+    NULL AS token4,
+    NULL AS token5,
+    NULL AS token6,
+    NULL AS token7,
     'dodo-v2' AS platform,
     'v2' AS version,
     _log_id AS _id,
     _inserted_timestamp
-FROM 
+  FROM
     {{ ref('silver_dex__dodo_v2_pools') }}
-WHERE token0 IS NOT NULL
+  WHERE
+    token0 IS NOT NULL
+
 {% if is_incremental() and 'dodo_v2' not in var('HEAL_MODELS') %}
-AND
-  _inserted_timestamp >= (
-    SELECT
-      MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
-    FROM
-      {{ this }}
-  )
+AND _inserted_timestamp >= (
+  SELECT
+    MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
+  FROM
+    {{ this }}
+)
 {% endif %}
 ),
-
 frax AS (
-
-SELECT
+  SELECT
     block_number,
     block_timestamp,
     tx_hash,
     factory_address AS contract_address,
     pool_address,
     NULL AS pool_name,
+    NULL AS fee,
+    NULL AS tick_spacing,
     token0,
     token1,
+    NULL AS token2,
+    NULL AS token3,
+    NULL AS token4,
+    NULL AS token5,
+    NULL AS token6,
+    NULL AS token7,
     'fraxswap' AS platform,
     'v1' AS version,
     _log_id AS _id,
     _inserted_timestamp
-FROM
+  FROM
     {{ ref('silver_dex__fraxswap_pools') }}
+
 {% if is_incremental() and 'frax' not in var('HEAL_MODELS') %}
 WHERE
   _inserted_timestamp >= (
@@ -199,24 +261,31 @@ WHERE
   )
 {% endif %}
 ),
-
 kyberswap_v1_dynamic AS (
-
-SELECT
+  SELECT
     block_number,
     block_timestamp,
     tx_hash,
     contract_address,
     pool_address,
     NULL AS pool_name,
+    NULL AS fee,
+    NULL AS tick_spacing,
     token0,
     token1,
+    NULL AS token2,
+    NULL AS token3,
+    NULL AS token4,
+    NULL AS token5,
+    NULL AS token6,
+    NULL AS token7,
     'kyberswap-v1' AS platform,
     'v1-dynamic' AS version,
     _log_id AS _id,
     _inserted_timestamp
-FROM
+  FROM
     {{ ref('silver_dex__kyberswap_v1_dynamic_pools') }}
+
 {% if is_incremental() and 'kyberswap_v1_dynamic' not in var('HEAL_MODELS') %}
 WHERE
   _inserted_timestamp >= (
@@ -227,24 +296,31 @@ WHERE
   )
 {% endif %}
 ),
-
 kyberswap_v1_static AS (
-
-SELECT
+  SELECT
     block_number,
     block_timestamp,
     tx_hash,
     contract_address,
     pool_address,
     NULL AS pool_name,
+    NULL AS fee,
+    NULL AS tick_spacing,
     token0,
     token1,
+    NULL AS token2,
+    NULL AS token3,
+    NULL AS token4,
+    NULL AS token5,
+    NULL AS token6,
+    NULL AS token7,
     'kyberswap-v1' AS platform,
     'v1-static' AS version,
     _log_id AS _id,
     _inserted_timestamp
-FROM
+  FROM
     {{ ref('silver_dex__kyberswap_v1_static_pools') }}
+
 {% if is_incremental() and 'kyberswap_v1_static' not in var('HEAL_MODELS') %}
 WHERE
   _inserted_timestamp >= (
@@ -255,25 +331,31 @@ WHERE
   )
 {% endif %}
 ),
-
 kyberswap_v2_elastic AS (
-
-SELECT
+  SELECT
     block_number,
     block_timestamp,
     tx_hash,
     contract_address,
     pool_address,
+    NULL AS pool_name,
     swap_fee_units AS fee,
     tick_distance AS tick_spacing,
     token0,
     token1,
+    NULL AS token2,
+    NULL AS token3,
+    NULL AS token4,
+    NULL AS token5,
+    NULL AS token6,
+    NULL AS token7,
     'kyberswap-v2' AS platform,
     'v2' AS version,
     _log_id AS _id,
     _inserted_timestamp
-FROM
+  FROM
     {{ ref('silver_dex__kyberswap_v2_elastic_pools') }}
+
 {% if is_incremental() and 'kyberswap_v2_elastic' not in var('HEAL_MODELS') %}
 WHERE
   _inserted_timestamp >= (
@@ -284,24 +366,31 @@ WHERE
   )
 {% endif %}
 ),
-
 sushi AS (
-
-SELECT
+  SELECT
     block_number,
     block_timestamp,
     tx_hash,
     contract_address,
     pool_address,
     NULL AS pool_name,
+    NULL AS fee,
+    NULL AS tick_spacing,
     token0,
     token1,
+    NULL AS token2,
+    NULL AS token3,
+    NULL AS token4,
+    NULL AS token5,
+    NULL AS token6,
+    NULL AS token7,
     'sushiswap' AS platform,
     'v1' AS version,
     _log_id AS _id,
     _inserted_timestamp
-FROM
+  FROM
     {{ ref('silver_dex__sushi_pools') }}
+
 {% if is_incremental() and 'sushi' not in var('HEAL_MODELS') %}
 WHERE
   _inserted_timestamp >= (
@@ -312,24 +401,31 @@ WHERE
   )
 {% endif %}
 ),
-
 trader_joe_v1 AS (
-
-SELECT
+  SELECT
     block_number,
     block_timestamp,
     tx_hash,
     contract_address,
     pool_address,
     NULL AS pool_name,
+    NULL AS fee,
+    NULL AS tick_spacing,
     token0,
     token1,
+    NULL AS token2,
+    NULL AS token3,
+    NULL AS token4,
+    NULL AS token5,
+    NULL AS token6,
+    NULL AS token7,
     'trader-joe-v1' AS platform,
     'v1' AS version,
     _log_id AS _id,
     _inserted_timestamp
-FROM
+  FROM
     {{ ref('silver_dex__trader_joe_v1_pools') }}
+
 {% if is_incremental() and 'trader_joe_v1' not in var('HEAL_MODELS') %}
 WHERE
   _inserted_timestamp >= (
@@ -340,24 +436,31 @@ WHERE
   )
 {% endif %}
 ),
-
 trader_joe_v2 AS (
-
-SELECT
+  SELECT
     block_number,
     block_timestamp,
     tx_hash,
     contract_address,
     lb_pair AS pool_address,
     NULL AS pool_name,
+    NULL AS fee,
+    NULL AS tick_spacing,
     tokenX AS token0,
     tokenY AS token1,
+    NULL AS token2,
+    NULL AS token3,
+    NULL AS token4,
+    NULL AS token5,
+    NULL AS token6,
+    NULL AS token7,
     'trader-joe-v2' AS platform,
     'v2' AS version,
     _log_id AS _id,
     _inserted_timestamp
-FROM
+  FROM
     {{ ref('silver_dex__trader_joe_v2_pools') }}
+
 {% if is_incremental() and 'trader_joe_v2' not in var('HEAL_MODELS') %}
 WHERE
   _inserted_timestamp >= (
@@ -368,24 +471,31 @@ WHERE
   )
 {% endif %}
 ),
-
 zyberswap AS (
-
-SELECT
+  SELECT
     block_number,
     block_timestamp,
     tx_hash,
     contract_address,
     pool_address,
     NULL AS pool_name,
+    NULL AS fee,
+    NULL AS tick_spacing,
     token0,
     token1,
+    NULL AS token2,
+    NULL AS token3,
+    NULL AS token4,
+    NULL AS token5,
+    NULL AS token6,
+    NULL AS token7,
     'zyberswap' AS platform,
     'v1' AS version,
     _log_id AS _id,
     _inserted_timestamp
-FROM
+  FROM
     {{ ref('silver_dex__zyberswap_pools') }}
+
 {% if is_incremental() and 'zyberswap' not in var('HEAL_MODELS') %}
 WHERE
   _inserted_timestamp >= (
@@ -396,25 +506,31 @@ WHERE
   )
 {% endif %}
 ),
-
 ramses_v2 AS (
-
-SELECT
+  SELECT
     created_block AS block_number,
     created_time AS block_timestamp,
     created_tx_hash AS tx_hash,
     contract_address,
     pool_address,
+    NULL AS pool_name,
     fee,
     tick_spacing,
     token0_address AS token0,
     token1_address AS token1,
+    NULL AS token2,
+    NULL AS token3,
+    NULL AS token4,
+    NULL AS token5,
+    NULL AS token6,
+    NULL AS token7,
     'ramses-v2' AS platform,
     'v2' AS version,
     _log_id AS _id,
     _inserted_timestamp
-FROM
+  FROM
     {{ ref('silver_dex__ramses_v2_pools') }}
+
 {% if is_incremental() and 'ramses_v2' not in var('HEAL_MODELS') %}
 WHERE
   _inserted_timestamp >= (
@@ -425,25 +541,31 @@ WHERE
   )
 {% endif %}
 ),
-
 uni_v3 AS (
-
-SELECT
+  SELECT
     created_block AS block_number,
     created_time AS block_timestamp,
     created_tx_hash AS tx_hash,
     contract_address,
     pool_address,
+    NULL AS pool_name,
     fee,
     tick_spacing,
     token0_address AS token0,
     token1_address AS token1,
+    NULL AS token2,
+    NULL AS token3,
+    NULL AS token4,
+    NULL AS token5,
+    NULL AS token6,
+    NULL AS token7,
     'uniswap-v3' AS platform,
     'v3' AS version,
     _log_id AS _id,
     _inserted_timestamp
-FROM
+  FROM
     {{ ref('silver_dex__univ3_pools') }}
+
 {% if is_incremental() and 'uni_v3' not in var('HEAL_MODELS') %}
 WHERE
   _inserted_timestamp >= (
@@ -455,22 +577,30 @@ WHERE
 {% endif %}
 ),
 uni_v2 AS (
-
-SELECT
+  SELECT
     block_number,
     block_timestamp,
     tx_hash,
     contract_address,
     pool_address,
     NULL AS pool_name,
+    NULL AS fee,
+    NULL AS tick_spacing,
     token0,
     token1,
+    NULL AS token2,
+    NULL AS token3,
+    NULL AS token4,
+    NULL AS token5,
+    NULL AS token6,
+    NULL AS token7,
     'uniswap-v2' AS platform,
     'v2' AS version,
     _log_id AS _id,
     _inserted_timestamp
-FROM
+  FROM
     {{ ref('silver_dex__univ2_pools') }}
+
 {% if is_incremental() and 'uni_v2' not in var('HEAL_MODELS') %}
 WHERE
   _inserted_timestamp >= (
@@ -482,22 +612,30 @@ WHERE
 {% endif %}
 ),
 sparta AS (
-
-SELECT
+  SELECT
     block_number,
     block_timestamp,
     tx_hash,
     contract_address,
     pool_address,
     NULL AS pool_name,
+    NULL AS fee,
+    NULL AS tick_spacing,
     token0,
     token1,
+    NULL AS token2,
+    NULL AS token3,
+    NULL AS token4,
+    NULL AS token5,
+    NULL AS token6,
+    NULL AS token7,
     'uniswap-v2' AS platform,
     'v2' AS version,
     _log_id AS _id,
     _inserted_timestamp
-FROM
+  FROM
     {{ ref('silver_dex__sparta_pools') }}
+
 {% if is_incremental() and 'sparta' not in var('HEAL_MODELS') %}
 WHERE
   _inserted_timestamp >= (
@@ -508,184 +646,813 @@ WHERE
   )
 {% endif %}
 ),
-
-all_pools_standard AS (
-    SELECT *
-    FROM camelot
-    UNION ALL
-    SELECT *
-    FROM dodo_v1
-    UNION ALL
-    SELECT *
-    FROM dodo_v2
-    UNION ALL
-    SELECT *
-    FROM frax
-    UNION ALL
-    SELECT *
-    FROM kyberswap_v1_dynamic
-    UNION ALL
-    SELECT *
-    FROM kyberswap_v1_static
-    UNION ALL
-    SELECT *
-    FROM sushi
-    UNION ALL
-    SELECT *
-    FROM uni_v2
-    UNION ALL
-    SELECT *
-    FROM sparta
-    UNION ALL
-    SELECT *
-    FROM trader_joe_v1
-    UNION ALL
-    SELECT *
-    FROM trader_joe_v2
-    UNION ALL
-    SELECT *
-    FROM zyberswap
+all_pools AS (
+  SELECT
+    *
+  FROM
+    camelot
+  UNION ALL
+  SELECT
+    *
+  FROM
+    dodo_v1
+  UNION ALL
+  SELECT
+    *
+  FROM
+    dodo_v2
+  UNION ALL
+  SELECT
+    *
+  FROM
+    frax
+  UNION ALL
+  SELECT
+    *
+  FROM
+    kyberswap_v1_dynamic
+  UNION ALL
+  SELECT
+    *
+  FROM
+    kyberswap_v1_static
+  UNION ALL
+  SELECT
+    *
+  FROM
+    sushi
+  UNION ALL
+  SELECT
+    *
+  FROM
+    uni_v2
+  UNION ALL
+  SELECT
+    *
+  FROM
+    sparta
+  UNION ALL
+  SELECT
+    *
+  FROM
+    trader_joe_v1
+  UNION ALL
+  SELECT
+    *
+  FROM
+    trader_joe_v2
+  UNION ALL
+  SELECT
+    *
+  FROM
+    zyberswap
+  UNION ALL
+  SELECT
+    *
+  FROM
+    uni_v3
+  UNION ALL
+  SELECT
+    *
+  FROM
+    ramses_v2
+  UNION ALL
+  SELECT
+    *
+  FROM
+    kyberswap_v2_elastic
+  UNION ALL
+  SELECT
+    *
+  FROM
+    balancer
+  UNION ALL
+  SELECT
+    *
+  FROM
+    curve
 ),
-
-all_pools_v3 AS (
-    SELECT *
-    FROM uni_v3
-    UNION ALL
-    SELECT *
-    FROM ramses_v2
-    UNION ALL
-    SELECT *
-    FROM kyberswap_v2_elastic
-),
-
-all_pools_other AS (
-    SELECT *
-    FROM balancer
-    UNION ALL
-    SELECT *
-    FROM curve
-),
-
-FINAL AS (
-    SELECT
-        block_number,
-        block_timestamp,
-        tx_hash,
-        contract_address,
-        pool_address,
-        CASE
-          WHEN pool_name IS NULL 
-            THEN CONCAT(  
-                    COALESCE(c0.symbol,CONCAT(SUBSTRING(token0, 1, 5),'...',SUBSTRING(token0, 39, 42))),
-                    '-',
-                    COALESCE(c1.symbol,CONCAT(SUBSTRING(token1, 1, 5),'...',SUBSTRING(token1, 39, 42)))
-                  ) 
-          ELSE pool_name
-        END AS pool_name,
-        OBJECT_CONSTRUCT('token0',token0,'token1',token1) AS tokens,
-        OBJECT_CONSTRUCT('token0',c0.symbol,'token1',c1.symbol) AS symbols,
-        OBJECT_CONSTRUCT('token0',c0.decimals,'token1',c1.decimals) AS decimals,
-        platform,
-        version,
-        _id,
-        p._inserted_timestamp
-    FROM all_pools_standard p 
-    LEFT JOIN contracts c0
-        ON c0.address = p.token0
-    LEFT JOIN contracts c1
-        ON c1.address = p.token1
-    UNION ALL
-    SELECT
-        block_number,
-        block_timestamp,
-        tx_hash,
-        contract_address,
-        pool_address,
-        CASE
-            WHEN platform = 'kyberswap-v2' 
-                THEN CONCAT(COALESCE(c0.symbol,CONCAT(SUBSTRING(token0, 1, 5),'...',SUBSTRING(token0, 39, 42))),'-',COALESCE(c1.symbol,CONCAT(SUBSTRING(token1, 1, 5),'...',SUBSTRING(token1, 39, 42))),' ',COALESCE(fee,0),' ',COALESCE(tick_spacing,0))
-            WHEN platform = 'ramses-v2' 
-                THEN CONCAT(COALESCE(c0.symbol,CONCAT(SUBSTRING(token0, 1, 5),'...',SUBSTRING(token0, 39, 42))),'-',COALESCE(c1.symbol,CONCAT(SUBSTRING(token1, 1, 5),'...',SUBSTRING(token1, 39, 42))),' ',COALESCE(fee,0),' ',COALESCE(tick_spacing,0))
-            WHEN platform = 'uniswap-v3' 
-                THEN CONCAT(COALESCE(c0.symbol,CONCAT(SUBSTRING(token0, 1, 5),'...',SUBSTRING(token0, 39, 42))),'-',COALESCE(c1.symbol,CONCAT(SUBSTRING(token1, 1, 5),'...',SUBSTRING(token1, 39, 42))),' ',COALESCE(fee,0),' ',COALESCE(tick_spacing,0),' UNI-V3 LP')
-        END AS pool_name,
-        OBJECT_CONSTRUCT('token0',token0,'token1',token1) AS tokens,
-        OBJECT_CONSTRUCT('token0',c0.symbol,'token1',c1.symbol) AS symbols,
-        OBJECT_CONSTRUCT('token0',c0.decimals,'token1',c1.decimals) AS decimals,
-        platform,
-        version,
-        _id,
-        p._inserted_timestamp
-    FROM all_pools_v3 p 
-    LEFT JOIN contracts c0
-        ON c0.address = p.token0
-    LEFT JOIN contracts c1
-        ON c1.address = p.token1
-    UNION ALL
-    SELECT
-        block_number,
-        block_timestamp,
-        tx_hash,
-        contract_address,
-        pool_address,
-        CASE 
-          WHEN pool_name IS NULL 
-            THEN CONCAT(
-                  COALESCE(c0.symbol, SUBSTRING(token0, 1, 5) || '...' || SUBSTRING(token0, 39, 42)),
-                  CASE WHEN token1 IS NOT NULL THEN '-' || COALESCE(c1.symbol, SUBSTRING(token1, 1, 5) || '...' || SUBSTRING(token1, 39, 42)) ELSE '' END,
-                  CASE WHEN token2 IS NOT NULL THEN '-' || COALESCE(c2.symbol, SUBSTRING(token2, 1, 5) || '...' || SUBSTRING(token2, 39, 42)) ELSE '' END,
-                  CASE WHEN token3 IS NOT NULL THEN '-' || COALESCE(c3.symbol, SUBSTRING(token3, 1, 5) || '...' || SUBSTRING(token3, 39, 42)) ELSE '' END,
-                  CASE WHEN token4 IS NOT NULL THEN '-' || COALESCE(c4.symbol, SUBSTRING(token4, 1, 5) || '...' || SUBSTRING(token4, 39, 42)) ELSE '' END,
-                  CASE WHEN token5 IS NOT NULL THEN '-' || COALESCE(c5.symbol, SUBSTRING(token5, 1, 5) || '...' || SUBSTRING(token5, 39, 42)) ELSE '' END,
-                  CASE WHEN token6 IS NOT NULL THEN '-' || COALESCE(c6.symbol, SUBSTRING(token6, 1, 5) || '...' || SUBSTRING(token6, 39, 42)) ELSE '' END,
-                  CASE WHEN token7 IS NOT NULL THEN '-' || COALESCE(c7.symbol, SUBSTRING(token7, 1, 5) || '...' || SUBSTRING(token7, 39, 42)) ELSE '' END
-              ) 
-            ELSE pool_name
-        END AS pool_name,
-        OBJECT_CONSTRUCT('token0', token0, 'token1', token1, 'token2', token2, 'token3', token3, 'token4', token4, 'token5', token5, 'token6', token6, 'token7', token7) AS tokens,
-        OBJECT_CONSTRUCT('token0', c0.symbol, 'token1', c1.symbol, 'token2', c2.symbol, 'token3', c3.symbol, 'token4', c4.symbol, 'token5', c5.symbol, 'token6', c6.symbol, 'token7', c7.symbol) AS symbols,
-        OBJECT_CONSTRUCT('token0', c0.decimals, 'token1', c1.decimals, 'token2', c2.decimals, 'token3', c3.decimals, 'token4', c4.decimals, 'token5', c5.decimals, 'token6', c6.decimals, 'token7', c7.decimals) AS decimals,
-        platform,
-        version,
-        _id,
-        p._inserted_timestamp
-    FROM all_pools_other p
-    LEFT JOIN contracts c0
-        ON c0.address = p.token0
-    LEFT JOIN contracts c1
-        ON c1.address = p.token1
-    LEFT JOIN contracts c2
-        ON c2.address = p.token2
-    LEFT JOIN contracts c3
-        ON c3.address = p.token3
-    LEFT JOIN contracts c4
-        ON c4.address = p.token4
-    LEFT JOIN contracts c5
-        ON c5.address = p.token5
-    LEFT JOIN contracts c6
-        ON c6.address = p.token6
-    LEFT JOIN contracts c7
-        ON c7.address = p.token7
-)
-
-SELECT
+complete_lps AS (
+  SELECT
     block_number,
     block_timestamp,
     tx_hash,
+    p.contract_address,
+    pool_address,
+    CASE
+      WHEN pool_name IS NOT NULL THEN pool_name
+      WHEN pool_name IS NULL
+      AND platform IN (
+        'uniswap-v3',
+        'kyberswap-v2',
+        'ramses-v2'
+      ) THEN CONCAT(
+        COALESCE(
+          c0.token_symbol,
+          CONCAT(SUBSTRING(token0, 1, 5), '...', SUBSTRING(token0, 39, 42))
+        ),
+        '-',
+        COALESCE(
+          c1.token_symbol,
+          CONCAT(SUBSTRING(token1, 1, 5), '...', SUBSTRING(token1, 39, 42))
+        ),
+        ' ',
+        COALESCE(
+          fee,
+          0
+        ),
+        ' ',
+        COALESCE(
+          tick_spacing,
+          0
+        ),
+        CASE
+          WHEN platform = 'uniswap-v3' THEN ' UNI-V3 LP'
+          WHEN platform = 'kyberswap-v2' THEN ''
+          WHEN platform = 'ramses-v2' THEN ''
+        END
+      )
+      WHEN pool_name IS NULL
+      AND platform IN (
+        'balancer',
+        'curve'
+      ) THEN CONCAT(
+        COALESCE(c0.token_symbol, SUBSTRING(token0, 1, 5) || '...' || SUBSTRING(token0, 39, 42)),
+        CASE
+          WHEN token1 IS NOT NULL THEN '-' || COALESCE(c1.token_symbol, SUBSTRING(token1, 1, 5) || '...' || SUBSTRING(token1, 39, 42))
+          ELSE ''
+        END,
+        CASE
+          WHEN token2 IS NOT NULL THEN '-' || COALESCE(c2.token_symbol, SUBSTRING(token2, 1, 5) || '...' || SUBSTRING(token2, 39, 42))
+          ELSE ''
+        END,
+        CASE
+          WHEN token3 IS NOT NULL THEN '-' || COALESCE(c3.token_symbol, SUBSTRING(token3, 1, 5) || '...' || SUBSTRING(token3, 39, 42))
+          ELSE ''
+        END,
+        CASE
+          WHEN token4 IS NOT NULL THEN '-' || COALESCE(c4.token_symbol, SUBSTRING(token4, 1, 5) || '...' || SUBSTRING(token4, 39, 42))
+          ELSE ''
+        END,
+        CASE
+          WHEN token5 IS NOT NULL THEN '-' || COALESCE(c5.token_symbol, SUBSTRING(token5, 1, 5) || '...' || SUBSTRING(token5, 39, 42))
+          ELSE ''
+        END,
+        CASE
+          WHEN token6 IS NOT NULL THEN '-' || COALESCE(c6.token_symbol, SUBSTRING(token6, 1, 5) || '...' || SUBSTRING(token6, 39, 42))
+          ELSE ''
+        END,
+        CASE
+          WHEN token7 IS NOT NULL THEN '-' || COALESCE(c7.token_symbol, SUBSTRING(token7, 1, 5) || '...' || SUBSTRING(token7, 39, 42))
+          ELSE ''
+        END
+      )
+      ELSE CONCAT(
+        COALESCE(
+          c0.token_symbol,
+          CONCAT(SUBSTRING(token0, 1, 5), '...', SUBSTRING(token0, 39, 42))
+        ),
+        '-',
+        COALESCE(
+          c1.token_symbol,
+          CONCAT(SUBSTRING(token1, 1, 5), '...', SUBSTRING(token1, 39, 42))
+        )
+      )
+    END AS pool_name,
+    fee,
+    tick_spacing,
+    token0,
+    token1,
+    token2,
+    token3,
+    token4,
+    token5,
+    token6,
+    token7,
+    OBJECT_CONSTRUCT(
+      'token0',
+      token0,
+      'token1',
+      token1,
+      'token2',
+      token2,
+      'token3',
+      token3,
+      'token4',
+      token4,
+      'token5',
+      token5,
+      'token6',
+      token6,
+      'token7',
+      token7
+    ) AS tokens,
+    OBJECT_CONSTRUCT(
+      'token0',
+      c0.token_symbol,
+      'token1',
+      c1.token_symbol,
+      'token2',
+      c2.token_symbol,
+      'token3',
+      c3.token_symbol,
+      'token4',
+      c4.token_symbol,
+      'token5',
+      c5.token_symbol,
+      'token6',
+      c6.token_symbol,
+      'token7',
+      c7.token_symbol
+    ) AS symbols,
+    OBJECT_CONSTRUCT(
+      'token0',
+      c0.token_decimals,
+      'token1',
+      c1.token_decimals,
+      'token2',
+      c2.token_decimals,
+      'token3',
+      c3.token_decimals,
+      'token4',
+      c4.token_decimals,
+      'token5',
+      c5.token_decimals,
+      'token6',
+      c6.token_decimals,
+      'token7',
+      c7.token_decimals
+    ) AS decimals,
     platform,
     version,
-    contract_address,
-    pool_address,
-    pool_name,
-    tokens,
-    symbols,
-    decimals,
     _id,
-    _inserted_timestamp,
+    p._inserted_timestamp
+  FROM
+    all_pools p
+    LEFT JOIN contracts c0
+    ON c0.contract_address = p.token0
+    LEFT JOIN contracts c1
+    ON c1.contract_address = p.token1
+    LEFT JOIN contracts c2
+    ON c2.contract_address = p.token2
+    LEFT JOIN contracts c3
+    ON c3.contract_address = p.token3
+    LEFT JOIN contracts c4
+    ON c4.contract_address = p.token4
+    LEFT JOIN contracts c5
+    ON c5.contract_address = p.token5
+    LEFT JOIN contracts c6
+    ON c6.contract_address = p.token6
+    LEFT JOIN contracts c7
+    ON c7.contract_address = p.token7
+),
+
+{% if is_incremental() and var(
+  'HEAL_MODEL'
+) %}
+heal_model AS (
+  SELECT
+    block_number,
+    block_timestamp,
+    tx_hash,
+    t0.contract_address,
+    pool_address,
+    CASE
+      WHEN pool_name IS NOT NULL THEN pool_name
+      WHEN pool_name IS NULL
+      AND platform IN (
+        'uniswap-v3',
+        'kyberswap-v2',
+        'ramses-v2'
+      ) THEN CONCAT(
+        COALESCE(
+          c0.token_symbol,
+          CONCAT(SUBSTRING(token0, 1, 5), '...', SUBSTRING(token0, 39, 42))
+        ),
+        '-',
+        COALESCE(
+          c1.token_symbol,
+          CONCAT(SUBSTRING(token1, 1, 5), '...', SUBSTRING(token1, 39, 42))
+        ),
+        ' ',
+        COALESCE(
+          fee,
+          0
+        ),
+        ' ',
+        COALESCE(
+          tick_spacing,
+          0
+        ),
+        CASE
+          WHEN platform = 'uniswap-v3' THEN ' UNI-V3 LP'
+          WHEN platform = 'kyberswap-v2' THEN ''
+          WHEN platform = 'ramses-v2' THEN ''
+        END
+      )
+      WHEN pool_name IS NULL
+      AND platform IN (
+        'balancer',
+        'curve'
+      ) THEN CONCAT(
+        COALESCE(c0.token_symbol, SUBSTRING(token0, 1, 5) || '...' || SUBSTRING(token0, 39, 42)),
+        CASE
+          WHEN token1 IS NOT NULL THEN '-' || COALESCE(c1.token_symbol, SUBSTRING(token1, 1, 5) || '...' || SUBSTRING(token1, 39, 42))
+          ELSE ''
+        END,
+        CASE
+          WHEN token2 IS NOT NULL THEN '-' || COALESCE(c2.token_symbol, SUBSTRING(token2, 1, 5) || '...' || SUBSTRING(token2, 39, 42))
+          ELSE ''
+        END,
+        CASE
+          WHEN token3 IS NOT NULL THEN '-' || COALESCE(c3.token_symbol, SUBSTRING(token3, 1, 5) || '...' || SUBSTRING(token3, 39, 42))
+          ELSE ''
+        END,
+        CASE
+          WHEN token4 IS NOT NULL THEN '-' || COALESCE(c4.token_symbol, SUBSTRING(token4, 1, 5) || '...' || SUBSTRING(token4, 39, 42))
+          ELSE ''
+        END,
+        CASE
+          WHEN token5 IS NOT NULL THEN '-' || COALESCE(c5.token_symbol, SUBSTRING(token5, 1, 5) || '...' || SUBSTRING(token5, 39, 42))
+          ELSE ''
+        END,
+        CASE
+          WHEN token6 IS NOT NULL THEN '-' || COALESCE(c6.token_symbol, SUBSTRING(token6, 1, 5) || '...' || SUBSTRING(token6, 39, 42))
+          ELSE ''
+        END,
+        CASE
+          WHEN token7 IS NOT NULL THEN '-' || COALESCE(c7.token_symbol, SUBSTRING(token7, 1, 5) || '...' || SUBSTRING(token7, 39, 42))
+          ELSE ''
+        END
+      )
+      ELSE CONCAT(
+        COALESCE(
+          c0.token_symbol,
+          CONCAT(SUBSTRING(token0, 1, 5), '...', SUBSTRING(token0, 39, 42))
+        ),
+        '-',
+        COALESCE(
+          c1.token_symbol,
+          CONCAT(SUBSTRING(token1, 1, 5), '...', SUBSTRING(token1, 39, 42))
+        )
+      )
+    END AS pool_name,
+    fee,
+    tick_spacing,
+    token0,
+    token1,
+    token2,
+    token3,
+    token4,
+    token5,
+    token6,
+    token7,
+    OBJECT_CONSTRUCT(
+      'token0',
+      token0,
+      'token1',
+      token1,
+      'token2',
+      token2,
+      'token3',
+      token3,
+      'token4',
+      token4,
+      'token5',
+      token5,
+      'token6',
+      token6,
+      'token7',
+      token7
+    ) AS tokens,
+    OBJECT_CONSTRUCT(
+      'token0',
+      c0.token_symbol,
+      'token1',
+      c1.token_symbol,
+      'token2',
+      c2.token_symbol,
+      'token3',
+      c3.token_symbol,
+      'token4',
+      c4.token_symbol,
+      'token5',
+      c5.token_symbol,
+      'token6',
+      c6.token_symbol,
+      'token7',
+      c7.token_symbol
+    ) AS symbols,
+    OBJECT_CONSTRUCT(
+      'token0',
+      c0.token_decimals,
+      'token1',
+      c1.token_decimals,
+      'token2',
+      c2.token_decimals,
+      'token3',
+      c3.token_decimals,
+      'token4',
+      c4.token_decimals,
+      'token5',
+      c5.token_decimals,
+      'token6',
+      c6.token_decimals,
+      'token7',
+      c7.token_decimals
+    ) AS decimals,
+    platform,
+    version,
+    _id,
+    t0._inserted_timestamp
+  FROM
+    {{ this }}
+    t0
+    LEFT JOIN contracts c0
+    ON c0.contract_address = t0.token0
+    LEFT JOIN contracts c1
+    ON c1.contract_address = t0.token1
+    LEFT JOIN contracts c2
+    ON c2.contract_address = t0.token2
+    LEFT JOIN contracts c3
+    ON c3.contract_address = t0.token3
+    LEFT JOIN contracts c4
+    ON c4.contract_address = t0.token4
+    LEFT JOIN contracts c5
+    ON c5.contract_address = t0.token5
+    LEFT JOIN contracts c6
+    ON c6.contract_address = t0.token6
+    LEFT JOIN contracts c7
+    ON c7.contract_address = t0.token7
+  WHERE
+    CONCAT(
+      t0.block_number,
+      '-',
+      t0.platform,
+      '-',
+      t0.version
+    ) IN (
+      SELECT
+        CONCAT(
+          t1.block_number,
+          '-',
+          t1.platform,
+          '-',
+          t1.version
+        )
+      FROM
+        {{ this }}
+        t1
+      WHERE
+        t1.decimals :token0 :: INT IS NULL
+        AND t1._inserted_timestamp < (
+          SELECT
+            MAX(
+              _inserted_timestamp
+            ) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
+          FROM
+            {{ this }}
+        )
+        AND EXISTS (
+          SELECT
+            1
+          FROM
+            {{ ref('silver__contracts') }} C
+          WHERE
+            C._inserted_timestamp > DATEADD('DAY', -14, SYSDATE())
+            AND C.token_decimals IS NOT NULL
+            AND C.contract_address = t1.tokens :token0 :: STRING)
+          GROUP BY
+            1
+        )
+        OR CONCAT(
+          t0.block_number,
+          '-',
+          t0.platform,
+          '-',
+          t0.version
+        ) IN (
+          SELECT
+            CONCAT(
+              t2.block_number,
+              '-',
+              t2.platform,
+              '-',
+              t2.version
+            )
+          FROM
+            {{ this }}
+            t2
+          WHERE
+            t2.decimals :token1 :: INT IS NULL
+            AND t2._inserted_timestamp < (
+              SELECT
+                MAX(
+                  _inserted_timestamp
+                ) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
+              FROM
+                {{ this }}
+            )
+            AND EXISTS (
+              SELECT
+                1
+              FROM
+                {{ ref('silver__contracts') }} C
+              WHERE
+                C._inserted_timestamp > DATEADD('DAY', -14, SYSDATE())
+                AND C.token_decimals IS NOT NULL
+                AND C.contract_address = t2.tokens :token1 :: STRING)
+              GROUP BY
+                1
+            )
+            OR CONCAT(
+              t0.block_number,
+              '-',
+              t0.platform,
+              '-',
+              t0.version
+            ) IN (
+              SELECT
+                CONCAT(
+                  t3.block_number,
+                  '-',
+                  t3.platform,
+                  '-',
+                  t3.version
+                )
+              FROM
+                {{ this }}
+                t3
+              WHERE
+                t3.decimals :token2 :: INT IS NULL
+                AND t3._inserted_timestamp < (
+                  SELECT
+                    MAX(
+                      _inserted_timestamp
+                    ) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
+                  FROM
+                    {{ this }}
+                )
+                AND EXISTS (
+                  SELECT
+                    1
+                  FROM
+                    {{ ref('silver__contracts') }} C
+                  WHERE
+                    C._inserted_timestamp > DATEADD('DAY', -14, SYSDATE())
+                    AND C.token_decimals IS NOT NULL
+                    AND C.contract_address = t3.tokens :token2 :: STRING)
+                  GROUP BY
+                    1
+                )
+                OR CONCAT(
+                  t0.block_number,
+                  '-',
+                  t0.platform,
+                  '-',
+                  t0.version
+                ) IN (
+                  SELECT
+                    CONCAT(
+                      t4.block_number,
+                      '-',
+                      t4.platform,
+                      '-',
+                      t4.version
+                    )
+                  FROM
+                    {{ this }}
+                    t4
+                  WHERE
+                    t4.decimals :token3 :: INT IS NULL
+                    AND t4._inserted_timestamp < (
+                      SELECT
+                        MAX(
+                          _inserted_timestamp
+                        ) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
+                      FROM
+                        {{ this }}
+                    )
+                    AND EXISTS (
+                      SELECT
+                        1
+                      FROM
+                        {{ ref('silver__contracts') }} C
+                      WHERE
+                        C._inserted_timestamp > DATEADD('DAY', -14, SYSDATE())
+                        AND C.token_decimals IS NOT NULL
+                        AND C.contract_address = t4.tokens :token3 :: STRING)
+                      GROUP BY
+                        1
+                    )
+                    OR CONCAT(
+                      t0.block_number,
+                      '-',
+                      t0.platform,
+                      '-',
+                      t0.version
+                    ) IN (
+                      SELECT
+                        CONCAT(
+                          t5.block_number,
+                          '-',
+                          t5.platform,
+                          '-',
+                          t5.version
+                        )
+                      FROM
+                        {{ this }}
+                        t5
+                      WHERE
+                        t5.decimals :token4 :: INT IS NULL
+                        AND t5._inserted_timestamp < (
+                          SELECT
+                            MAX(
+                              _inserted_timestamp
+                            ) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
+                          FROM
+                            {{ this }}
+                        )
+                        AND EXISTS (
+                          SELECT
+                            1
+                          FROM
+                            {{ ref('silver__contracts') }} C
+                          WHERE
+                            C._inserted_timestamp > DATEADD('DAY', -14, SYSDATE())
+                            AND C.token_decimals IS NOT NULL
+                            AND C.contract_address = t5.tokens :token4 :: STRING)
+                          GROUP BY
+                            1
+                        )
+                        OR CONCAT(
+                          t0.block_number,
+                          '-',
+                          t0.platform,
+                          '-',
+                          t0.version
+                        ) IN (
+                          SELECT
+                            CONCAT(
+                              t6.block_number,
+                              '-',
+                              t6.platform,
+                              '-',
+                              t6.version
+                            )
+                          FROM
+                            {{ this }}
+                            t6
+                          WHERE
+                            t6.decimals :token5 :: INT IS NULL
+                            AND t6._inserted_timestamp < (
+                              SELECT
+                                MAX(
+                                  _inserted_timestamp
+                                ) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
+                              FROM
+                                {{ this }}
+                            )
+                            AND EXISTS (
+                              SELECT
+                                1
+                              FROM
+                                {{ ref('silver__contracts') }} C
+                              WHERE
+                                C._inserted_timestamp > DATEADD('DAY', -14, SYSDATE())
+                                AND C.token_decimals IS NOT NULL
+                                AND C.contract_address = t6.tokens :token5 :: STRING)
+                              GROUP BY
+                                1
+                            )
+                            OR CONCAT(
+                              t0.block_number,
+                              '-',
+                              t0.platform,
+                              '-',
+                              t0.version
+                            ) IN (
+                              SELECT
+                                CONCAT(
+                                  t7.block_number,
+                                  '-',
+                                  t7.platform,
+                                  '-',
+                                  t7.version
+                                )
+                              FROM
+                                {{ this }}
+                                t7
+                              WHERE
+                                t7.decimals :token6 :: INT IS NULL
+                                AND t7._inserted_timestamp < (
+                                  SELECT
+                                    MAX(
+                                      _inserted_timestamp
+                                    ) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
+                                  FROM
+                                    {{ this }}
+                                )
+                                AND EXISTS (
+                                  SELECT
+                                    1
+                                  FROM
+                                    {{ ref('silver__contracts') }} C
+                                  WHERE
+                                    C._inserted_timestamp > DATEADD('DAY', -14, SYSDATE())
+                                    AND C.token_decimals IS NOT NULL
+                                    AND C.contract_address = t7.tokens :token6 :: STRING)
+                                  GROUP BY
+                                    1
+                                )
+                                OR CONCAT(
+                                  t0.block_number,
+                                  '-',
+                                  t0.platform,
+                                  '-',
+                                  t0.version
+                                ) IN (
+                                  SELECT
+                                    CONCAT(
+                                      t8.block_number,
+                                      '-',
+                                      t8.platform,
+                                      '-',
+                                      t8.version
+                                    )
+                                  FROM
+                                    {{ this }}
+                                    t8
+                                  WHERE
+                                    t8.decimals :token7 :: INT IS NULL
+                                    AND t8._inserted_timestamp < (
+                                      SELECT
+                                        MAX(
+                                          _inserted_timestamp
+                                        ) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
+                                      FROM
+                                        {{ this }}
+                                    )
+                                    AND EXISTS (
+                                      SELECT
+                                        1
+                                      FROM
+                                        {{ ref('silver__contracts') }} C
+                                      WHERE
+                                        C._inserted_timestamp > DATEADD('DAY', -14, SYSDATE())
+                                        AND C.token_decimals IS NOT NULL
+                                        AND C.contract_address = t8.tokens :token7 :: STRING)
+                                      GROUP BY
+                                        1
+                                    )
+                                ),
+                              {% endif %}
+
+                              FINAL AS (
+                                SELECT
+                                  *
+                                FROM
+                                  complete_lps
+
+{% if is_incremental() and var(
+  'HEAL_MODEL'
+) %}
+UNION ALL
+SELECT
+  *
+FROM
+  heal_model
+{% endif %}
+)
+SELECT
+  block_number,
+  block_timestamp,
+  tx_hash,
+  platform,
+  version,
+  contract_address,
+  pool_address,
+  pool_name,
+  tokens,
+  symbols,
+  decimals,
+  fee,
+  tick_spacing,
+  token0,
+  token1,
+  token2,
+  token3,
+  token4,
+  token5,
+  token6,
+  token7,
+  _id,
+  _inserted_timestamp,
   {{ dbt_utils.generate_surrogate_key(
     ['pool_address']
   ) }} AS complete_dex_liquidity_pools_id,
   SYSDATE() AS inserted_timestamp,
   SYSDATE() AS modified_timestamp,
   '{{ invocation_id }}' AS _invocation_id
-FROM FINAL 
+FROM
+  FINAL

--- a/models/silver/defi/dex/silver_dex__complete_dex_liquidity_pools.sql
+++ b/models/silver/defi/dex/silver_dex__complete_dex_liquidity_pools.sql
@@ -45,7 +45,7 @@ balancer AS (
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
+      MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
     FROM
       {{ this }}
   )
@@ -112,7 +112,7 @@ curve AS (
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
+      MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
     FROM
       {{ this }}
   )
@@ -149,7 +149,7 @@ camelot AS (
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
+      MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
     FROM
       {{ this }}
   )
@@ -184,7 +184,7 @@ dodo_v1 AS (
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
+      MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
     FROM
       {{ this }}
   )
@@ -220,7 +220,7 @@ dodo_v2 AS (
 {% if is_incremental() and 'dodo_v2' not in var('HEAL_MODELS') %}
 AND _inserted_timestamp >= (
   SELECT
-    MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
+    MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
   FROM
     {{ this }}
 )
@@ -255,7 +255,7 @@ frax AS (
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
+      MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
     FROM
       {{ this }}
   )
@@ -290,7 +290,7 @@ kyberswap_v1_dynamic AS (
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
+      MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
     FROM
       {{ this }}
   )
@@ -325,7 +325,7 @@ kyberswap_v1_static AS (
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
+      MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
     FROM
       {{ this }}
   )
@@ -360,7 +360,7 @@ kyberswap_v2_elastic AS (
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
+      MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
     FROM
       {{ this }}
   )
@@ -395,7 +395,7 @@ sushi AS (
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
+      MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
     FROM
       {{ this }}
   )
@@ -430,7 +430,7 @@ trader_joe_v1 AS (
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
+      MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
     FROM
       {{ this }}
   )
@@ -465,7 +465,7 @@ trader_joe_v2 AS (
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
+      MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
     FROM
       {{ this }}
   )
@@ -500,7 +500,7 @@ zyberswap AS (
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
+      MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
     FROM
       {{ this }}
   )
@@ -535,7 +535,7 @@ ramses_v2 AS (
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
+      MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
     FROM
       {{ this }}
   )
@@ -570,7 +570,7 @@ uni_v3 AS (
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
+      MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
     FROM
       {{ this }}
   )
@@ -605,7 +605,7 @@ uni_v2 AS (
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
+      MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
     FROM
       {{ this }}
   )
@@ -640,7 +640,7 @@ sparta AS (
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
+      MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
     FROM
       {{ this }}
   )
@@ -1109,7 +1109,7 @@ heal_model AS (
           SELECT
             MAX(
               _inserted_timestamp
-            ) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
+            ) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
           FROM
             {{ this }}
         )
@@ -1149,7 +1149,7 @@ heal_model AS (
               SELECT
                 MAX(
                   _inserted_timestamp
-                ) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
+                ) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
               FROM
                 {{ this }}
             )
@@ -1189,7 +1189,7 @@ heal_model AS (
                   SELECT
                     MAX(
                       _inserted_timestamp
-                    ) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
+                    ) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
                   FROM
                     {{ this }}
                 )
@@ -1229,7 +1229,7 @@ heal_model AS (
                       SELECT
                         MAX(
                           _inserted_timestamp
-                        ) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
+                        ) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
                       FROM
                         {{ this }}
                     )
@@ -1269,7 +1269,7 @@ heal_model AS (
                           SELECT
                             MAX(
                               _inserted_timestamp
-                            ) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
+                            ) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
                           FROM
                             {{ this }}
                         )
@@ -1309,7 +1309,7 @@ heal_model AS (
                               SELECT
                                 MAX(
                                   _inserted_timestamp
-                                ) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
+                                ) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
                               FROM
                                 {{ this }}
                             )
@@ -1349,7 +1349,7 @@ heal_model AS (
                                   SELECT
                                     MAX(
                                       _inserted_timestamp
-                                    ) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
+                                    ) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
                                   FROM
                                     {{ this }}
                                 )
@@ -1389,7 +1389,7 @@ heal_model AS (
                                       SELECT
                                         MAX(
                                           _inserted_timestamp
-                                        ) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
+                                        ) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
                                       FROM
                                         {{ this }}
                                     )

--- a/models/silver/defi/dex/silver_dex__complete_dex_swaps.sql
+++ b/models/silver/defi/dex/silver_dex__complete_dex_swaps.sql
@@ -7,32 +7,8 @@
   tags = ['curated','reorg','heal']
 ) }}
 
-WITH contracts AS (
+WITH ramses_v2 AS (
 
-  SELECT
-    contract_address as address,
-    token_symbol as symbol,
-    token_name as NAME,
-    token_decimals as decimals
-  FROM
-    {{ ref('silver__contracts') }}
-),
-prices AS (
-  SELECT
-    HOUR,
-    token_address,
-    price
-  FROM
-    {{ ref('price__ez_prices_hourly') }}
-  WHERE
-    token_address IN (
-      SELECT
-        DISTINCT address
-      FROM
-        contracts
-    )
-),
-ramses_v2_swaps AS (
   SELECT
     block_number,
     block_timestamp,
@@ -41,90 +17,34 @@ ramses_v2_swaps AS (
     origin_from_address,
     origin_to_address,
     pool_address AS contract_address,
-    NULL AS pool_name,
     'Swap' AS event_name,
-    amount0_unadj / pow(10, COALESCE(c1.decimals, 18)) AS amount0_adjusted,
-    amount1_unadj / pow(10, COALESCE(c2.decimals, 18)) AS amount1_adjusted,
-    CASE
-      WHEN c1.decimals IS NOT NULL THEN ROUND(
-        p1.price * amount0_adjusted,
-        2
-      )
-    END AS amount0_usd,
-    CASE
-      WHEN c2.decimals IS NOT NULL THEN ROUND(
-        p2.price * amount1_adjusted,
-        2
-      )
-    END AS amount1_usd,
     CASE
       WHEN amount0_unadj > 0 THEN ABS(amount0_unadj)
       ELSE ABS(amount1_unadj)
     END AS amount_in_unadj,
     CASE
-      WHEN amount0_unadj > 0 THEN ABS(amount0_adjusted)
-      ELSE ABS(amount1_adjusted)
-    END AS amount_in,
-    CASE
-      WHEN amount0_unadj > 0 THEN ABS(amount0_usd)
-      ELSE ABS(amount1_usd)
-    END AS amount_in_usd,
-    CASE
       WHEN amount0_unadj < 0 THEN ABS(amount0_unadj)
       ELSE ABS(amount1_unadj)
     END AS amount_out_unadj,
     CASE
-      WHEN amount0_unadj < 0 THEN ABS(amount0_adjusted)
-      ELSE ABS(amount1_adjusted)
-    END AS amount_out,
+      WHEN amount0_unadj > 0 THEN token0_address
+      ELSE token1_address
+    END AS token_in,
     CASE
-      WHEN amount0_unadj < 0 THEN ABS(amount0_usd)
-      ELSE ABS(amount1_usd)
-    END AS amount_out_usd,
+      WHEN amount0_unadj < 0 THEN token0_address
+      ELSE token1_address
+    END AS token_out,
     sender,
     recipient AS tx_to,
     event_index,
     'ramses-v2' AS platform,
     'v2' AS version,
-    CASE
-      WHEN amount0_unadj > 0 THEN token0_address
-      ELSE token1_address
-    END AS token_in,
-    CASE
-      WHEN amount0_unadj < 0 THEN token0_address
-      ELSE token1_address
-    END AS token_out,
-    CASE
-      WHEN amount0_unadj > 0 THEN c1.symbol
-      ELSE c2.symbol
-    END AS symbol_in,
-    CASE
-      WHEN amount0_unadj < 0 THEN c1.symbol
-      ELSE c2.symbol
-    END AS symbol_out,
     _log_id,
     _inserted_timestamp
   FROM
     {{ ref('silver_dex__ramses_v2_swaps') }}
-    s
-    LEFT JOIN contracts c1
-    ON c1.address = s.token0_address
-    LEFT JOIN contracts c2
-    ON c2.address = s.token1_address
-    LEFT JOIN prices p1
-    ON s.token0_address = p1.token_address
-    AND DATE_TRUNC(
-      'hour',
-      block_timestamp
-    ) = p1.hour
-    LEFT JOIN prices p2
-    ON s.token1_address = p2.token_address
-    AND DATE_TRUNC(
-      'hour',
-      block_timestamp
-    ) = p2.hour
 
-{% if is_incremental() and 'ramses_v2_swaps' not in var('HEAL_MODELS') %}
+{% if is_incremental() and 'ramses_v2' not in var('HEAL_MODELS') %}
 WHERE
   _inserted_timestamp >= (
     SELECT
@@ -134,7 +54,7 @@ WHERE
   )
 {% endif %}
 ),
-univ3_swaps AS (
+univ3 AS (
   SELECT
     block_number,
     block_timestamp,
@@ -143,51 +63,15 @@ univ3_swaps AS (
     origin_from_address,
     origin_to_address,
     pool_address AS contract_address,
-    NULL AS pool_name,
     'Swap' AS event_name,
-    amount0_unadj / pow(10, COALESCE(c1.decimals, 18)) AS amount0_adjusted,
-    amount1_unadj / pow(10, COALESCE(c2.decimals, 18)) AS amount1_adjusted,
-    CASE
-      WHEN c1.decimals IS NOT NULL THEN ROUND(
-        p1.price * amount0_adjusted,
-        2
-      )
-    END AS amount0_usd,
-    CASE
-      WHEN c2.decimals IS NOT NULL THEN ROUND(
-        p2.price * amount1_adjusted,
-        2
-      )
-    END AS amount1_usd,
     CASE
       WHEN amount0_unadj > 0 THEN ABS(amount0_unadj)
       ELSE ABS(amount1_unadj)
     END AS amount_in_unadj,
     CASE
-      WHEN amount0_unadj > 0 THEN ABS(amount0_adjusted)
-      ELSE ABS(amount1_adjusted)
-    END AS amount_in,
-    CASE
-      WHEN amount0_unadj > 0 THEN ABS(amount0_usd)
-      ELSE ABS(amount1_usd)
-    END AS amount_in_usd,
-    CASE
       WHEN amount0_unadj < 0 THEN ABS(amount0_unadj)
       ELSE ABS(amount1_unadj)
     END AS amount_out_unadj,
-    CASE
-      WHEN amount0_unadj < 0 THEN ABS(amount0_adjusted)
-      ELSE ABS(amount1_adjusted)
-    END AS amount_out,
-    CASE
-      WHEN amount0_unadj < 0 THEN ABS(amount0_usd)
-      ELSE ABS(amount1_usd)
-    END AS amount_out_usd,
-    sender,
-    recipient AS tx_to,
-    event_index,
-    'uniswap-v3' AS platform,
-    'v3' AS version,
     CASE
       WHEN amount0_unadj > 0 THEN token0_address
       ELSE token1_address
@@ -196,37 +80,17 @@ univ3_swaps AS (
       WHEN amount0_unadj < 0 THEN token0_address
       ELSE token1_address
     END AS token_out,
-    CASE
-      WHEN amount0_unadj > 0 THEN c1.symbol
-      ELSE c2.symbol
-    END AS symbol_in,
-    CASE
-      WHEN amount0_unadj < 0 THEN c1.symbol
-      ELSE c2.symbol
-    END AS symbol_out,
+    sender,
+    recipient AS tx_to,
+    event_index,
+    'uniswap-v3' AS platform,
+    'v3' AS version,
     _log_id,
     _inserted_timestamp
   FROM
     {{ ref('silver_dex__univ3_swaps') }}
-    s
-    LEFT JOIN contracts c1
-    ON c1.address = s.token0_address
-    LEFT JOIN contracts c2
-    ON c2.address = s.token1_address
-    LEFT JOIN prices p1
-    ON s.token0_address = p1.token_address
-    AND DATE_TRUNC(
-      'hour',
-      block_timestamp
-    ) = p1.hour
-    LEFT JOIN prices p2
-    ON s.token1_address = p2.token_address
-    AND DATE_TRUNC(
-      'hour',
-      block_timestamp
-    ) = p2.hour
 
-{% if is_incremental() and 'univ3_swaps' not in var('HEAL_MODELS') %}
+{% if is_incremental() and 'univ3' not in var('HEAL_MODELS') %}
 WHERE
   _inserted_timestamp >= (
     SELECT
@@ -236,7 +100,7 @@ WHERE
   )
 {% endif %}
 ),
-balancer_swaps AS (
+balancer AS (
   SELECT
     block_number,
     block_timestamp,
@@ -245,40 +109,22 @@ balancer_swaps AS (
     origin_from_address,
     origin_to_address,
     contract_address,
-    NULL AS pool_name,
     event_name,
-    c1.decimals AS decimals_in,
-    c1.symbol AS symbol_in,
     amount_in_unadj,
-    CASE
-      WHEN decimals_in IS NULL THEN amount_in_unadj
-      ELSE (amount_in_unadj / pow(10, decimals_in))
-    END AS amount_in,
-    c2.decimals AS decimals_out,
-    c2.symbol AS symbol_out,
     amount_out_unadj,
-    CASE
-      WHEN decimals_out IS NULL THEN amount_out_unadj
-      ELSE (amount_out_unadj / pow(10, decimals_out))
-    END AS amount_out,
+    token_in,
+    token_out,
     sender,
     tx_to,
     event_index,
     platform,
     'v1' AS version,
-    token_in,
-    token_out,
     _log_id,
     _inserted_timestamp
   FROM
     {{ ref('silver_dex__balancer_swaps') }}
-    s
-    LEFT JOIN contracts c1
-    ON s.token_in = c1.address
-    LEFT JOIN contracts c2
-    ON s.token_out = c2.address
 
-{% if is_incremental() and 'balancer_swaps' not in var('HEAL_MODELS') %}
+{% if is_incremental() and 'balancer' not in var('HEAL_MODELS') %}
 WHERE
   _inserted_timestamp >= (
     SELECT
@@ -288,7 +134,7 @@ WHERE
   )
 {% endif %}
 ),
-curve_swaps AS (
+curve AS (
   SELECT
     block_number,
     block_timestamp,
@@ -298,57 +144,21 @@ curve_swaps AS (
     origin_to_address,
     contract_address,
     event_name,
-    s.tokens_sold AS amount_in_unadj,
-    s.tokens_bought AS amount_out_unadj,
+    tokens_sold AS amount_in_unadj,
+    tokens_bought AS amount_out_unadj,
+    token_in,
+    token_out,
     sender,
     tx_to,
     event_index,
     platform,
     'v1' AS version,
-    token_in,
-    token_out,
-    COALESCE(
-      c1.symbol,
-      s.symbol_in
-    ) AS token_symbol_in,
-    COALESCE(
-      c2.symbol,
-      s.symbol_out
-    ) AS token_symbol_out,
-    NULL AS pool_name,
-    c1.decimals AS decimals_in,
-    CASE
-      WHEN decimals_in IS NOT NULL THEN s.tokens_sold / pow(
-        10,
-        decimals_in
-      )
-      ELSE s.tokens_sold
-    END AS amount_in,
-    c2.decimals AS decimals_out,
-    CASE
-      WHEN decimals_out IS NOT NULL THEN s.tokens_bought / pow(
-        10,
-        decimals_out
-      )
-      ELSE s.tokens_bought
-    END AS amount_out,
     _log_id,
     _inserted_timestamp
   FROM
     {{ ref('silver_dex__curve_swaps') }}
-    s
-    LEFT JOIN contracts c1
-    ON c1.address = s.token_in
-    LEFT JOIN contracts c2
-    ON c2.address = s.token_out
-  WHERE
-    amount_out <> 0
-    AND COALESCE(
-      token_symbol_in,
-      'null'
-    ) <> COALESCE(token_symbol_out, 'null')
 
-{% if is_incremental() and 'curve_swaps' not in var('HEAL_MODELS') %}
+{% if is_incremental() and 'curve' not in var('HEAL_MODELS') %}
 AND _inserted_timestamp >= (
   SELECT
     MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
@@ -357,7 +167,7 @@ AND _inserted_timestamp >= (
 )
 {% endif %}
 ),
-trader_joe_v1_swaps AS (
+trader_joe_v1 AS (
   SELECT
     block_number,
     block_timestamp,
@@ -367,39 +177,21 @@ trader_joe_v1_swaps AS (
     origin_to_address,
     contract_address,
     event_name,
-    c1.decimals AS decimals_in,
-    c1.symbol AS symbol_in,
     amount_in_unadj,
-    CASE
-      WHEN decimals_in IS NULL THEN amount_in_unadj
-      ELSE (amount_in_unadj / pow(10, decimals_in))
-    END AS amount_in,
-    c2.decimals AS decimals_out,
-    c2.symbol AS symbol_out,
     amount_out_unadj,
-    CASE
-      WHEN decimals_out IS NULL THEN amount_out_unadj
-      ELSE (amount_out_unadj / pow(10, decimals_out))
-    END AS amount_out,
+    token_in,
+    token_out,
     sender,
     tx_to,
     event_index,
     platform,
     'v1' AS version,
-    token_in,
-    token_out,
-    NULL AS pool_name,
     _log_id,
     _inserted_timestamp
   FROM
     {{ ref('silver_dex__trader_joe_v1_swaps') }}
-    s
-    LEFT JOIN contracts c1
-    ON s.token_in = c1.address
-    LEFT JOIN contracts c2
-    ON s.token_out = c2.address
 
-{% if is_incremental() and 'trader_joe_v1_swaps' not in var('HEAL_MODELS') %}
+{% if is_incremental() and 'trader_joe_v1' not in var('HEAL_MODELS') %}
 WHERE
   _inserted_timestamp >= (
     SELECT
@@ -409,7 +201,7 @@ WHERE
   )
 {% endif %}
 ),
-trader_joe_v2_swaps AS (
+trader_joe_v2 AS (
   SELECT
     block_number,
     block_timestamp,
@@ -419,39 +211,21 @@ trader_joe_v2_swaps AS (
     origin_to_address,
     contract_address,
     event_name,
-    c1.decimals AS decimals_in,
-    c1.symbol AS symbol_in,
     amount_in_unadj,
-    CASE
-      WHEN decimals_in IS NULL THEN amount_in_unadj
-      ELSE (amount_in_unadj / pow(10, decimals_in))
-    END AS amount_in,
-    c2.decimals AS decimals_out,
-    c2.symbol AS symbol_out,
     amount_out_unadj,
-    CASE
-      WHEN decimals_out IS NULL THEN amount_out_unadj
-      ELSE (amount_out_unadj / pow(10, decimals_out))
-    END AS amount_out,
+    token_in,
+    token_out,
     sender,
     tx_to,
     event_index,
     platform,
     'v2' AS version,
-    token_in,
-    token_out,
-    NULL AS pool_name,
     _log_id,
     _inserted_timestamp
   FROM
     {{ ref('silver_dex__trader_joe_v2_swaps') }}
-    s
-    LEFT JOIN contracts c1
-    ON s.token_in = c1.address
-    LEFT JOIN contracts c2
-    ON s.token_out = c2.address
 
-{% if is_incremental() and 'trader_joe_v2_swaps' not in var('HEAL_MODELS') %}
+{% if is_incremental() and 'trader_joe_v2' not in var('HEAL_MODELS') %}
 WHERE
   _inserted_timestamp >= (
     SELECT
@@ -461,7 +235,7 @@ WHERE
   )
 {% endif %}
 ),
-trader_joe_v2_1_swaps AS (
+trader_joe_v2_1 AS (
   SELECT
     block_number,
     block_timestamp,
@@ -471,39 +245,21 @@ trader_joe_v2_1_swaps AS (
     origin_to_address,
     contract_address,
     event_name,
-    c1.decimals AS decimals_in,
-    c1.symbol AS symbol_in,
     amount_in_unadj,
-    CASE
-      WHEN decimals_in IS NULL THEN amount_in_unadj
-      ELSE (amount_in_unadj / pow(10, decimals_in))
-    END AS amount_in,
-    c2.decimals AS decimals_out,
-    c2.symbol AS symbol_out,
     amount_out_unadj,
-    CASE
-      WHEN decimals_out IS NULL THEN amount_out_unadj
-      ELSE (amount_out_unadj / pow(10, decimals_out))
-    END AS amount_out,
+    token_in,
+    token_out,
     sender,
     tx_to,
     event_index,
     platform,
     'v2.1' AS version,
-    token_in,
-    token_out,
-    NULL AS pool_name,
     _log_id,
     _inserted_timestamp
   FROM
     {{ ref('silver_dex__trader_joe_v2_1_swaps') }}
-    s
-    LEFT JOIN contracts c1
-    ON s.token_in = c1.address
-    LEFT JOIN contracts c2
-    ON s.token_out = c2.address
 
-{% if is_incremental() and 'trader_joe_v2_1_swaps' not in var('HEAL_MODELS') %}
+{% if is_incremental() and 'trader_joe_v2_1' not in var('HEAL_MODELS') %}
 WHERE
   _inserted_timestamp >= (
     SELECT
@@ -513,7 +269,7 @@ WHERE
   )
 {% endif %}
 ),
-woofi_swaps AS (
+woofi AS (
   SELECT
     block_number,
     block_timestamp,
@@ -523,49 +279,21 @@ woofi_swaps AS (
     origin_to_address,
     contract_address,
     event_name,
-    c1.decimals AS decimals_in,
-    c1.symbol AS symbol_in,
     amount_in_unadj,
-    CASE
-      WHEN decimals_in IS NULL THEN amount_in_unadj
-      ELSE (amount_in_unadj / pow(10, decimals_in))
-    END AS amount_in,
-    c2.decimals AS decimals_out,
-    c2.symbol AS symbol_out,
     amount_out_unadj,
-    CASE
-      WHEN decimals_out IS NULL THEN amount_out_unadj
-      ELSE (amount_out_unadj / pow(10, decimals_out))
-    END AS amount_out,
+    token_in,
+    token_out,
     sender,
     tx_to,
     event_index,
     platform,
     'v1' AS version,
-    token_in,
-    token_out,
-    CONCAT(
-      LEAST(
-          COALESCE(symbol_in, CONCAT(SUBSTRING(token_in, 1, 5), '...', SUBSTRING(token_in, 39, 42))),
-          COALESCE(symbol_out, CONCAT(SUBSTRING(token_out, 1, 5), '...', SUBSTRING(token_out, 39, 42)))
-      ),
-      '-',
-      GREATEST(
-          COALESCE(symbol_in, CONCAT(SUBSTRING(token_in, 1, 5), '...', SUBSTRING(token_in, 39, 42))),
-          COALESCE(symbol_out, CONCAT(SUBSTRING(token_out, 1, 5), '...', SUBSTRING(token_out, 39, 42)))
-      )
-    ) AS pool_name,
     _log_id,
     _inserted_timestamp
   FROM
     {{ ref('silver_dex__woofi_swaps') }}
-    s
-    LEFT JOIN contracts c1
-    ON s.token_in = c1.address
-    LEFT JOIN contracts c2
-    ON s.token_out = c2.address
 
-{% if is_incremental() and 'woofi_swaps' not in var('HEAL_MODELS') %}
+{% if is_incremental() and 'woofi' not in var('HEAL_MODELS') %}
 WHERE
   _inserted_timestamp >= (
     SELECT
@@ -575,7 +303,7 @@ WHERE
   )
 {% endif %}
 ),
-hashflow_swaps AS (
+hashflow AS (
   SELECT
     block_number,
     block_timestamp,
@@ -585,49 +313,21 @@ hashflow_swaps AS (
     origin_to_address,
     contract_address,
     event_name,
-    c1.decimals AS decimals_in,
-    c1.symbol AS symbol_in,
     amount_in_unadj,
-    CASE
-      WHEN decimals_in IS NULL THEN amount_in_unadj
-      ELSE (amount_in_unadj / pow(10, decimals_in))
-    END AS amount_in,
-    c2.decimals AS decimals_out,
-    c2.symbol AS symbol_out,
     amount_out_unadj,
-    CASE
-      WHEN decimals_out IS NULL THEN amount_out_unadj
-      ELSE (amount_out_unadj / pow(10, decimals_out))
-    END AS amount_out,
+    token_in,
+    token_out,
     sender,
     tx_to,
     event_index,
     platform,
     'v1' AS version,
-    token_in,
-    token_out,
-    CONCAT(
-      LEAST(
-          COALESCE(symbol_in, CONCAT(SUBSTRING(token_in, 1, 5), '...', SUBSTRING(token_in, 39, 42))),
-          COALESCE(symbol_out, CONCAT(SUBSTRING(token_out, 1, 5), '...', SUBSTRING(token_out, 39, 42)))
-      ),
-      '-',
-      GREATEST(
-          COALESCE(symbol_in, CONCAT(SUBSTRING(token_in, 1, 5), '...', SUBSTRING(token_in, 39, 42))),
-          COALESCE(symbol_out, CONCAT(SUBSTRING(token_out, 1, 5), '...', SUBSTRING(token_out, 39, 42)))
-      )
-    ) AS pool_name,
     _log_id,
     _inserted_timestamp
   FROM
     {{ ref('silver_dex__hashflow_swaps') }}
-    s
-    LEFT JOIN contracts c1
-    ON s.token_in = c1.address
-    LEFT JOIN contracts c2
-    ON s.token_out = c2.address
 
-{% if is_incremental() and 'hashflow_swaps' not in var('HEAL_MODELS') %}
+{% if is_incremental() and 'hashflow' not in var('HEAL_MODELS') %}
 WHERE
   _inserted_timestamp >= (
     SELECT
@@ -637,7 +337,7 @@ WHERE
   )
 {% endif %}
 ),
-hashflow_v3_swaps AS (
+hashflow_v3 AS (
   SELECT
     block_number,
     block_timestamp,
@@ -647,49 +347,21 @@ hashflow_v3_swaps AS (
     origin_to_address,
     contract_address,
     event_name,
-    c1.decimals AS decimals_in,
-    c1.symbol AS symbol_in,
     amount_in_unadj,
-    CASE
-      WHEN decimals_in IS NULL THEN amount_in_unadj
-      ELSE (amount_in_unadj / pow(10, decimals_in))
-    END AS amount_in,
-    c2.decimals AS decimals_out,
-    c2.symbol AS symbol_out,
     amount_out_unadj,
-    CASE
-      WHEN decimals_out IS NULL THEN amount_out_unadj
-      ELSE (amount_out_unadj / pow(10, decimals_out))
-    END AS amount_out,
+    token_in,
+    token_out,
     sender,
     tx_to,
     event_index,
     platform,
     'v3' AS version,
-    token_in,
-    token_out,
-    CONCAT(
-      LEAST(
-          COALESCE(symbol_in, CONCAT(SUBSTRING(token_in, 1, 5), '...', SUBSTRING(token_in, 39, 42))),
-          COALESCE(symbol_out, CONCAT(SUBSTRING(token_out, 1, 5), '...', SUBSTRING(token_out, 39, 42)))
-      ),
-      '-',
-      GREATEST(
-          COALESCE(symbol_in, CONCAT(SUBSTRING(token_in, 1, 5), '...', SUBSTRING(token_in, 39, 42))),
-          COALESCE(symbol_out, CONCAT(SUBSTRING(token_out, 1, 5), '...', SUBSTRING(token_out, 39, 42)))
-      )
-    ) AS pool_name,
     _log_id,
     _inserted_timestamp
   FROM
     {{ ref('silver_dex__hashflow_v3_swaps') }}
-    s
-    LEFT JOIN contracts c1
-    ON s.token_in = c1.address
-    LEFT JOIN contracts c2
-    ON s.token_out = c2.address
 
-{% if is_incremental() and 'hashflow_v3_swaps' not in var('HEAL_MODELS') %}
+{% if is_incremental() and 'hashflow_v3' not in var('HEAL_MODELS') %}
 WHERE
   _inserted_timestamp >= (
     SELECT
@@ -699,7 +371,7 @@ WHERE
   )
 {% endif %}
 ),
-gmx_swaps AS (
+gmx AS (
   SELECT
     block_number,
     block_timestamp,
@@ -709,49 +381,21 @@ gmx_swaps AS (
     origin_to_address,
     contract_address,
     event_name,
-    c1.decimals AS decimals_in,
-    c1.symbol AS symbol_in,
     amount_in_unadj,
-    CASE
-      WHEN decimals_in IS NULL THEN amount_in_unadj
-      ELSE (amount_in_unadj / pow(10, decimals_in))
-    END AS amount_in,
-    c2.decimals AS decimals_out,
-    c2.symbol AS symbol_out,
     amount_out_unadj,
-    CASE
-      WHEN decimals_out IS NULL THEN amount_out_unadj
-      ELSE (amount_out_unadj / pow(10, decimals_out))
-    END AS amount_out,
+    token_in,
+    token_out,
     sender,
     tx_to,
     event_index,
     platform,
     'v1' AS version,
-    token_in,
-    token_out,
-    CONCAT(
-      LEAST(
-          COALESCE(symbol_in, CONCAT(SUBSTRING(token_in, 1, 5), '...', SUBSTRING(token_in, 39, 42))),
-          COALESCE(symbol_out, CONCAT(SUBSTRING(token_out, 1, 5), '...', SUBSTRING(token_out, 39, 42)))
-      ),
-      '-',
-      GREATEST(
-          COALESCE(symbol_in, CONCAT(SUBSTRING(token_in, 1, 5), '...', SUBSTRING(token_in, 39, 42))),
-          COALESCE(symbol_out, CONCAT(SUBSTRING(token_out, 1, 5), '...', SUBSTRING(token_out, 39, 42)))
-      )
-    ) AS pool_name,
     _log_id,
     _inserted_timestamp
   FROM
     {{ ref('silver_dex__gmx_swaps') }}
-    s
-    LEFT JOIN contracts c1
-    ON s.token_in = c1.address
-    LEFT JOIN contracts c2
-    ON s.token_out = c2.address
 
-{% if is_incremental() and 'gmx_swaps' not in var('HEAL_MODELS') %}
+{% if is_incremental() and 'gmx' not in var('HEAL_MODELS') %}
 WHERE
   _inserted_timestamp >= (
     SELECT
@@ -771,37 +415,19 @@ kyberswap_v1_dynamic AS (
     origin_to_address,
     contract_address,
     event_name,
-    c1.decimals AS decimals_in,
-    c1.symbol AS symbol_in,
     amount_in_unadj,
-    CASE
-      WHEN decimals_in IS NULL THEN amount_in_unadj
-      ELSE (amount_in_unadj / pow(10, decimals_in))
-    END AS amount_in,
-    c2.decimals AS decimals_out,
-    c2.symbol AS symbol_out,
     amount_out_unadj,
-    CASE
-      WHEN decimals_out IS NULL THEN amount_out_unadj
-      ELSE (amount_out_unadj / pow(10, decimals_out))
-    END AS amount_out,
+    token_in,
+    token_out,
     sender,
     tx_to,
     event_index,
     platform,
-    'v1' AS version,
-    token_in,
-    token_out,
-    NULL AS pool_name,
+    'v1-dynamic' AS version,
     _log_id,
     _inserted_timestamp
   FROM
-    {{ ref('silver_dex__kyberswap_v1_dynamic_swaps') }}
-    s
-    LEFT JOIN contracts c1
-    ON s.token_in = c1.address
-    LEFT JOIN contracts c2
-    ON s.token_out = c2.address
+    {{ ref('silver_dex__kyberswap_v1_dynamic') }}
 
 {% if is_incremental() and 'kyberswap_v1_dynamic' not in var('HEAL_MODELS') %}
 WHERE
@@ -823,37 +449,19 @@ kyberswap_v1_static AS (
     origin_to_address,
     contract_address,
     event_name,
-    c1.decimals AS decimals_in,
-    c1.symbol AS symbol_in,
     amount_in_unadj,
-    CASE
-      WHEN decimals_in IS NULL THEN amount_in_unadj
-      ELSE (amount_in_unadj / pow(10, decimals_in))
-    END AS amount_in,
-    c2.decimals AS decimals_out,
-    c2.symbol AS symbol_out,
     amount_out_unadj,
-    CASE
-      WHEN decimals_out IS NULL THEN amount_out_unadj
-      ELSE (amount_out_unadj / pow(10, decimals_out))
-    END AS amount_out,
+    token_in,
+    token_out,
     sender,
     tx_to,
     event_index,
     platform,
-    'v1' AS version,
-    token_in,
-    token_out,
-    NULL AS pool_name,
+    'v1-static' AS version,
     _log_id,
     _inserted_timestamp
   FROM
     {{ ref('silver_dex__kyberswap_v1_static_swaps') }}
-    s
-    LEFT JOIN contracts c1
-    ON s.token_in = c1.address
-    LEFT JOIN contracts c2
-    ON s.token_out = c2.address
 
 {% if is_incremental() and 'kyberswap_v1_static' not in var('HEAL_MODELS') %}
 WHERE
@@ -875,37 +483,19 @@ kyberswap_v2_elastic AS (
     origin_to_address,
     contract_address,
     event_name,
-    c1.decimals AS decimals_in,
-    c1.symbol AS symbol_in,
     amount_in_unadj,
-    CASE
-      WHEN decimals_in IS NULL THEN amount_in_unadj
-      ELSE (amount_in_unadj / pow(10, decimals_in))
-    END AS amount_in,
-    c2.decimals AS decimals_out,
-    c2.symbol AS symbol_out,
     amount_out_unadj,
-    CASE
-      WHEN decimals_out IS NULL THEN amount_out_unadj
-      ELSE (amount_out_unadj / pow(10, decimals_out))
-    END AS amount_out,
+    token_in,
+    token_out,
     sender,
     tx_to,
     event_index,
     platform,
     'v2' AS version,
-    token_in,
-    token_out,
-    NULL AS pool_name,
     _log_id,
     _inserted_timestamp
   FROM
     {{ ref('silver_dex__kyberswap_v2_elastic_swaps') }}
-    s
-    LEFT JOIN contracts c1
-    ON s.token_in = c1.address
-    LEFT JOIN contracts c2
-    ON s.token_out = c2.address
 
 {% if is_incremental() and 'kyberswap_v2_elastic' not in var('HEAL_MODELS') %}
 WHERE
@@ -917,7 +507,7 @@ WHERE
   )
 {% endif %}
 ),
-fraxswap_swaps AS (
+fraxswap AS (
   SELECT
     block_number,
     block_timestamp,
@@ -927,39 +517,21 @@ fraxswap_swaps AS (
     origin_to_address,
     contract_address,
     event_name,
-    c1.decimals AS decimals_in,
-    c1.symbol AS symbol_in,
     amount_in_unadj,
-    CASE
-      WHEN decimals_in IS NULL THEN amount_in_unadj
-      ELSE (amount_in_unadj / pow(10, decimals_in))
-    END AS amount_in,
-    c2.decimals AS decimals_out,
-    c2.symbol AS symbol_out,
     amount_out_unadj,
-    CASE
-      WHEN decimals_out IS NULL THEN amount_out_unadj
-      ELSE (amount_out_unadj / pow(10, decimals_out))
-    END AS amount_out,
+    token_in,
+    token_out,
     sender,
     tx_to,
     event_index,
     platform,
     'v1' AS version,
-    token_in,
-    token_out,
-    NULL AS pool_name,
     _log_id,
     _inserted_timestamp
   FROM
     {{ ref('silver_dex__fraxswap_swaps') }}
-    s
-    LEFT JOIN contracts c1
-    ON s.token_in = c1.address
-    LEFT JOIN contracts c2
-    ON s.token_out = c2.address
 
-{% if is_incremental() and 'fraxswap_swaps' not in var('HEAL_MODELS') %}
+{% if is_incremental() and 'fraxswap' not in var('HEAL_MODELS') %}
 WHERE
   _inserted_timestamp >= (
     SELECT
@@ -969,7 +541,7 @@ WHERE
   )
 {% endif %}
 ),
-sushi_swaps AS (
+sushi AS (
   SELECT
     block_number,
     block_timestamp,
@@ -979,39 +551,21 @@ sushi_swaps AS (
     origin_to_address,
     contract_address,
     event_name,
-    c1.decimals AS decimals_in,
-    c1.symbol AS symbol_in,
     amount_in_unadj,
-    CASE
-      WHEN decimals_in IS NULL THEN amount_in_unadj
-      ELSE (amount_in_unadj / pow(10, decimals_in))
-    END AS amount_in,
-    c2.decimals AS decimals_out,
-    c2.symbol AS symbol_out,
     amount_out_unadj,
-    CASE
-      WHEN decimals_out IS NULL THEN amount_out_unadj
-      ELSE (amount_out_unadj / pow(10, decimals_out))
-    END AS amount_out,
+    token_in,
+    token_out,
     sender,
     tx_to,
     event_index,
     platform,
     'v1' AS version,
-    token_in,
-    token_out,
-    NULL AS pool_name,
     _log_id,
     _inserted_timestamp
   FROM
     {{ ref('silver_dex__sushi_swaps') }}
-    s
-    LEFT JOIN contracts c1
-    ON s.token_in = c1.address
-    LEFT JOIN contracts c2
-    ON s.token_out = c2.address
 
-{% if is_incremental() and 'sushi_swaps' not in var('HEAL_MODELS') %}
+{% if is_incremental() and 'sushi' not in var('HEAL_MODELS') %}
 WHERE
   _inserted_timestamp >= (
     SELECT
@@ -1021,7 +575,7 @@ WHERE
   )
 {% endif %}
 ),
-univ2_swaps AS (
+univ2 AS (
   SELECT
     block_number,
     block_timestamp,
@@ -1031,39 +585,21 @@ univ2_swaps AS (
     origin_to_address,
     contract_address,
     event_name,
-    c1.decimals AS decimals_in,
-    c1.symbol AS symbol_in,
     amount_in_unadj,
-    CASE
-      WHEN decimals_in IS NULL THEN amount_in_unadj
-      ELSE (amount_in_unadj / pow(10, decimals_in))
-    END AS amount_in,
-    c2.decimals AS decimals_out,
-    c2.symbol AS symbol_out,
     amount_out_unadj,
-    CASE
-      WHEN decimals_out IS NULL THEN amount_out_unadj
-      ELSE (amount_out_unadj / pow(10, decimals_out))
-    END AS amount_out,
+    token_in,
+    token_out,
     sender,
     tx_to,
     event_index,
     platform,
     'v2' AS version,
-    token_in,
-    token_out,
-    NULL AS pool_name,
     _log_id,
     _inserted_timestamp
   FROM
     {{ ref('silver_dex__univ2_swaps') }}
-    s
-    LEFT JOIN contracts c1
-    ON s.token_in = c1.address
-    LEFT JOIN contracts c2
-    ON s.token_out = c2.address
 
-{% if is_incremental() and 'univ2_swaps' not in var('HEAL_MODELS') %}
+{% if is_incremental() and 'univ2' not in var('HEAL_MODELS') %}
 WHERE
   _inserted_timestamp >= (
     SELECT
@@ -1073,7 +609,7 @@ WHERE
   )
 {% endif %}
 ),
-sparta_swaps AS (
+sparta AS (
   SELECT
     block_number,
     block_timestamp,
@@ -1083,39 +619,21 @@ sparta_swaps AS (
     origin_to_address,
     contract_address,
     event_name,
-    c1.decimals AS decimals_in,
-    c1.symbol AS symbol_in,
     amount_in_unadj,
-    CASE
-      WHEN decimals_in IS NULL THEN amount_in_unadj
-      ELSE (amount_in_unadj / pow(10, decimals_in))
-    END AS amount_in,
-    c2.decimals AS decimals_out,
-    c2.symbol AS symbol_out,
     amount_out_unadj,
-    CASE
-      WHEN decimals_out IS NULL THEN amount_out_unadj
-      ELSE (amount_out_unadj / pow(10, decimals_out))
-    END AS amount_out,
+    token_in,
+    token_out,
     sender,
     tx_to,
     event_index,
     platform,
     'v1' AS version,
-    token_in,
-    token_out,
-    NULL AS pool_name,
     _log_id,
     _inserted_timestamp
   FROM
     {{ ref('silver_dex__sparta_swaps') }}
-    s
-    LEFT JOIN contracts c1
-    ON s.token_in = c1.address
-    LEFT JOIN contracts c2
-    ON s.token_out = c2.address
 
-{% if is_incremental() and 'sparta_swaps' not in var('HEAL_MODELS') %}
+{% if is_incremental() and 'sparta' not in var('HEAL_MODELS') %}
 WHERE
   _inserted_timestamp >= (
     SELECT
@@ -1125,7 +643,7 @@ WHERE
   )
 {% endif %}
 ),
-dodo_v1_swaps AS (
+dodo_v1 AS (
   SELECT
     block_number,
     block_timestamp,
@@ -1135,39 +653,21 @@ dodo_v1_swaps AS (
     origin_to_address,
     contract_address,
     event_name,
-    c1.decimals AS decimals_in,
-    c1.symbol AS symbol_in,
     amount_in_unadj,
-    CASE
-      WHEN decimals_in IS NULL THEN amount_in_unadj
-      ELSE (amount_in_unadj / pow(10, decimals_in))
-    END AS amount_in,
-    c2.decimals AS decimals_out,
-    c2.symbol AS symbol_out,
     amount_out_unadj,
-    CASE
-      WHEN decimals_out IS NULL THEN amount_out_unadj
-      ELSE (amount_out_unadj / pow(10, decimals_out))
-    END AS amount_out,
+    token_in,
+    token_out,
     sender,
     tx_to,
     event_index,
     platform,
     'v1' AS version,
-    token_in,
-    token_out,
-    NULL AS pool_name,
     _log_id,
     _inserted_timestamp
   FROM
     {{ ref('silver_dex__dodo_v1_swaps') }}
-    s
-    LEFT JOIN contracts c1
-    ON s.token_in = c1.address
-    LEFT JOIN contracts c2
-    ON s.token_out = c2.address
 
-{% if is_incremental() and 'dodo_v1_swaps' not in var('HEAL_MODELS') %}
+{% if is_incremental() and 'dodo_v1' not in var('HEAL_MODELS') %}
 WHERE
   _inserted_timestamp >= (
     SELECT
@@ -1177,7 +677,7 @@ WHERE
   )
 {% endif %}
 ),
-dodo_v2_swaps AS (
+dodo_v2 AS (
   SELECT
     block_number,
     block_timestamp,
@@ -1187,39 +687,21 @@ dodo_v2_swaps AS (
     origin_to_address,
     contract_address,
     event_name,
-    c1.decimals AS decimals_in,
-    c1.symbol AS symbol_in,
     amount_in_unadj,
-    CASE
-      WHEN decimals_in IS NULL THEN amount_in_unadj
-      ELSE (amount_in_unadj / pow(10, decimals_in))
-    END AS amount_in,
-    c2.decimals AS decimals_out,
-    c2.symbol AS symbol_out,
     amount_out_unadj,
-    CASE
-      WHEN decimals_out IS NULL THEN amount_out_unadj
-      ELSE (amount_out_unadj / pow(10, decimals_out))
-    END AS amount_out,
+    token_in,
+    token_out,
     sender,
     tx_to,
     event_index,
     platform,
     'v2' AS version,
-    token_in,
-    token_out,
-    NULL AS pool_name,
     _log_id,
     _inserted_timestamp
   FROM
     {{ ref('silver_dex__dodo_v2_swaps') }}
-    s
-    LEFT JOIN contracts c1
-    ON s.token_in = c1.address
-    LEFT JOIN contracts c2
-    ON s.token_out = c2.address
 
-{% if is_incremental() and 'dodo_v2_swaps' not in var('HEAL_MODELS') %}
+{% if is_incremental() and 'dodo_v2' not in var('HEAL_MODELS') %}
 WHERE
   _inserted_timestamp >= (
     SELECT
@@ -1229,7 +711,7 @@ WHERE
   )
 {% endif %}
 ),
-camelot_v2_swaps AS (
+camelot_v2 AS (
   SELECT
     block_number,
     block_timestamp,
@@ -1239,39 +721,21 @@ camelot_v2_swaps AS (
     origin_to_address,
     contract_address,
     event_name,
-    c1.decimals AS decimals_in,
-    c1.symbol AS symbol_in,
     amount_in_unadj,
-    CASE
-      WHEN decimals_in IS NULL THEN amount_in_unadj
-      ELSE (amount_in_unadj / pow(10, decimals_in))
-    END AS amount_in,
-    c2.decimals AS decimals_out,
-    c2.symbol AS symbol_out,
     amount_out_unadj,
-    CASE
-      WHEN decimals_out IS NULL THEN amount_out_unadj
-      ELSE (amount_out_unadj / pow(10, decimals_out))
-    END AS amount_out,
+    token_in,
+    token_out,
     sender,
     tx_to,
     event_index,
     platform,
     'v2' AS version,
-    token_in,
-    token_out,
-    NULL AS pool_name,
     _log_id,
     _inserted_timestamp
   FROM
     {{ ref('silver_dex__camelot_v2_swaps') }}
-    s
-    LEFT JOIN contracts c1
-    ON s.token_in = c1.address
-    LEFT JOIN contracts c2
-    ON s.token_out = c2.address
 
-{% if is_incremental() and 'camelot_v2_swaps' not in var('HEAL_MODELS') %}
+{% if is_incremental() and 'camelot_v2' not in var('HEAL_MODELS') %}
 WHERE
   _inserted_timestamp >= (
     SELECT
@@ -1281,7 +745,7 @@ WHERE
   )
 {% endif %}
 ),
-camelot_v3_swaps AS (
+camelot_v3 AS (
   SELECT
     block_number,
     block_timestamp,
@@ -1291,39 +755,21 @@ camelot_v3_swaps AS (
     origin_to_address,
     contract_address,
     event_name,
-    c1.decimals AS decimals_in,
-    c1.symbol AS symbol_in,
     amount_in_unadj,
-    CASE
-      WHEN decimals_in IS NULL THEN amount_in_unadj
-      ELSE (amount_in_unadj / pow(10, decimals_in))
-    END AS amount_in,
-    c2.decimals AS decimals_out,
-    c2.symbol AS symbol_out,
     amount_out_unadj,
-    CASE
-      WHEN decimals_out IS NULL THEN amount_out_unadj
-      ELSE (amount_out_unadj / pow(10, decimals_out))
-    END AS amount_out,
+    token_in,
+    token_out,
     sender,
     tx_to,
     event_index,
     platform,
     'v3' AS version,
-    token_in,
-    token_out,
-    NULL AS pool_name,
     _log_id,
     _inserted_timestamp
   FROM
     {{ ref('silver_dex__camelot_v3_swaps') }}
-    s
-    LEFT JOIN contracts c1
-    ON s.token_in = c1.address
-    LEFT JOIN contracts c2
-    ON s.token_out = c2.address
 
-{% if is_incremental() and 'camelot_v3_swaps' not in var('HEAL_MODELS') %}
+{% if is_incremental() and 'camelot_v3' not in var('HEAL_MODELS') %}
 WHERE
   _inserted_timestamp >= (
     SELECT
@@ -1333,7 +779,7 @@ WHERE
   )
 {% endif %}
 ),
-zyberswap_v2_swaps AS (
+zyberswap_v2 AS (
   SELECT
     block_number,
     block_timestamp,
@@ -1343,39 +789,21 @@ zyberswap_v2_swaps AS (
     origin_to_address,
     contract_address,
     event_name,
-    c1.decimals AS decimals_in,
-    c1.symbol AS symbol_in,
     amount_in_unadj,
-    CASE
-      WHEN decimals_in IS NULL THEN amount_in_unadj
-      ELSE (amount_in_unadj / pow(10, decimals_in))
-    END AS amount_in,
-    c2.decimals AS decimals_out,
-    c2.symbol AS symbol_out,
     amount_out_unadj,
-    CASE
-      WHEN decimals_out IS NULL THEN amount_out_unadj
-      ELSE (amount_out_unadj / pow(10, decimals_out))
-    END AS amount_out,
+    token_in,
+    token_out,
     sender,
     tx_to,
     event_index,
     platform,
     'v2' AS version,
-    token_in,
-    token_out,
-    NULL AS pool_name,
     _log_id,
     _inserted_timestamp
   FROM
     {{ ref('silver_dex__zyberswap_v2_swaps') }}
-    s
-    LEFT JOIN contracts c1
-    ON s.token_in = c1.address
-    LEFT JOIN contracts c2
-    ON s.token_out = c2.address
 
-{% if is_incremental() and 'zyberswap_v2_swaps' not in var('HEAL_MODELS') %}
+{% if is_incremental() and 'zyberswap_v2' not in var('HEAL_MODELS') %}
 WHERE
   _inserted_timestamp >= (
     SELECT
@@ -1385,7 +813,7 @@ WHERE
   )
 {% endif %}
 ),
-zyberswap_v3_swaps AS (
+zyberswap_v3 AS (
   SELECT
     block_number,
     block_timestamp,
@@ -1395,39 +823,21 @@ zyberswap_v3_swaps AS (
     origin_to_address,
     contract_address,
     event_name,
-    c1.decimals AS decimals_in,
-    c1.symbol AS symbol_in,
     amount_in_unadj,
-    CASE
-      WHEN decimals_in IS NULL THEN amount_in_unadj
-      ELSE (amount_in_unadj / pow(10, decimals_in))
-    END AS amount_in,
-    c2.decimals AS decimals_out,
-    c2.symbol AS symbol_out,
     amount_out_unadj,
-    CASE
-      WHEN decimals_out IS NULL THEN amount_out_unadj
-      ELSE (amount_out_unadj / pow(10, decimals_out))
-    END AS amount_out,
+    token_in,
+    token_out,
     sender,
     tx_to,
     event_index,
     platform,
     'v3' AS version,
-    token_in,
-    token_out,
-    NULL AS pool_name,
     _log_id,
     _inserted_timestamp
   FROM
     {{ ref('silver_dex__zyberswap_v3_swaps') }}
-    s
-    LEFT JOIN contracts c1
-    ON s.token_in = c1.address
-    LEFT JOIN contracts c2
-    ON s.token_out = c2.address
 
-{% if is_incremental() and 'zyberswap_v3_swaps' not in var('HEAL_MODELS') %}
+{% if is_incremental() and 'zyberswap_v3' not in var('HEAL_MODELS') %}
 WHERE
   _inserted_timestamp >= (
     SELECT
@@ -1437,868 +847,572 @@ WHERE
   )
 {% endif %}
 ),
---union all standard dex CTEs here (excludes amount_usd)
-all_dex_standard AS (
+all_dex AS (
   SELECT
-    block_number,
-    block_timestamp,
-    tx_hash,
-    origin_function_signature,
-    origin_from_address,
-    origin_to_address,
-    contract_address,
-    pool_name,
-    event_name,
-    amount_in_unadj,
-    amount_out_unadj,
-    amount_in,
-    amount_out,
-    sender,
-    tx_to,
-    event_index,
-    platform,
-    version,
-    token_in,
-    token_out,
-    symbol_in,
-    symbol_out,
-    decimals_in,
-    decimals_out,
-    _log_id,
-    _inserted_timestamp
+    *
   FROM
-    balancer_swaps
+    balancer
   UNION ALL
   SELECT
-    block_number,
-    block_timestamp,
-    tx_hash,
-    origin_function_signature,
-    origin_from_address,
-    origin_to_address,
-    contract_address,
-    pool_name,
-    event_name,
-    amount_in_unadj,
-    amount_out_unadj,
-    amount_in,
-    amount_out,
-    sender,
-    tx_to,
-    event_index,
-    platform,
-    version,
-    token_in,
-    token_out,
-    symbol_in,
-    symbol_out,
-    decimals_in,
-    decimals_out,
-    _log_id,
-    _inserted_timestamp
+    *
   FROM
-    camelot_v2_swaps
+    camelot_v2
   UNION ALL
   SELECT
-    block_number,
-    block_timestamp,
-    tx_hash,
-    origin_function_signature,
-    origin_from_address,
-    origin_to_address,
-    contract_address,
-    pool_name,
-    event_name,
-    amount_in_unadj,
-    amount_out_unadj,
-    amount_in,
-    amount_out,
-    sender,
-    tx_to,
-    event_index,
-    platform,
-    version,
-    token_in,
-    token_out,
-    symbol_in,
-    symbol_out,
-    decimals_in,
-    decimals_out,
-    _log_id,
-    _inserted_timestamp
+    *
   FROM
-    camelot_v3_swaps
+    camelot_v3
   UNION ALL
   SELECT
-    block_number,
-    block_timestamp,
-    tx_hash,
-    origin_function_signature,
-    origin_from_address,
-    origin_to_address,
-    contract_address,
-    pool_name,
-    event_name,
-    amount_in_unadj,
-    amount_out_unadj,
-    amount_in,
-    amount_out,
-    sender,
-    tx_to,
-    event_index,
-    platform,
-    version,
-    token_in,
-    token_out,
-    token_symbol_in AS symbol_in,
-    token_symbol_out AS symbol_out,
-    decimals_in,
-    decimals_out,
-    _log_id,
-    _inserted_timestamp
+    *
   FROM
-    curve_swaps
+    curve
   UNION ALL
   SELECT
-    block_number,
-    block_timestamp,
-    tx_hash,
-    origin_function_signature,
-    origin_from_address,
-    origin_to_address,
-    contract_address,
-    pool_name,
-    event_name,
-    amount_in_unadj,
-    amount_out_unadj,
-    amount_in,
-    amount_out,
-    sender,
-    tx_to,
-    event_index,
-    platform,
-    version,
-    token_in,
-    token_out,
-    symbol_in,
-    symbol_out,
-    decimals_in,
-    decimals_out,
-    _log_id,
-    _inserted_timestamp
+    *
   FROM
-    hashflow_swaps
+    hashflow
   UNION ALL
   SELECT
-    block_number,
-    block_timestamp,
-    tx_hash,
-    origin_function_signature,
-    origin_from_address,
-    origin_to_address,
-    contract_address,
-    pool_name,
-    event_name,
-    amount_in_unadj,
-    amount_out_unadj,
-    amount_in,
-    amount_out,
-    sender,
-    tx_to,
-    event_index,
-    platform,
-    version,
-    token_in,
-    token_out,
-    symbol_in,
-    symbol_out,
-    decimals_in,
-    decimals_out,
-    _log_id,
-    _inserted_timestamp
+    *
   FROM
-    hashflow_v3_swaps
+    hashflow_v3
   UNION ALL
   SELECT
-    block_number,
-    block_timestamp,
-    tx_hash,
-    origin_function_signature,
-    origin_from_address,
-    origin_to_address,
-    contract_address,
-    pool_name,
-    event_name,
-    amount_in_unadj,
-    amount_out_unadj,
-    amount_in,
-    amount_out,
-    sender,
-    tx_to,
-    event_index,
-    platform,
-    version,
-    token_in,
-    token_out,
-    symbol_in,
-    symbol_out,
-    decimals_in,
-    decimals_out,
-    _log_id,
-    _inserted_timestamp
+    *
   FROM
-    dodo_v1_swaps
+    dodo_v1
   UNION ALL
   SELECT
-    block_number,
-    block_timestamp,
-    tx_hash,
-    origin_function_signature,
-    origin_from_address,
-    origin_to_address,
-    contract_address,
-    pool_name,
-    event_name,
-    amount_in_unadj,
-    amount_out_unadj,
-    amount_in,
-    amount_out,
-    sender,
-    tx_to,
-    event_index,
-    platform,
-    version,
-    token_in,
-    token_out,
-    symbol_in,
-    symbol_out,
-    decimals_in,
-    decimals_out,
-    _log_id,
-    _inserted_timestamp
+    *
   FROM
-    dodo_v2_swaps
+    dodo_v2
   UNION ALL
   SELECT
-    block_number,
-    block_timestamp,
-    tx_hash,
-    origin_function_signature,
-    origin_from_address,
-    origin_to_address,
-    contract_address,
-    pool_name,
-    event_name,
-    amount_in_unadj,
-    amount_out_unadj,
-    amount_in,
-    amount_out,
-    sender,
-    tx_to,
-    event_index,
-    platform,
-    version,
-    token_in,
-    token_out,
-    symbol_in,
-    symbol_out,
-    decimals_in,
-    decimals_out,
-    _log_id,
-    _inserted_timestamp
+    *
   FROM
-    fraxswap_swaps
+    fraxswap
   UNION ALL
   SELECT
-    block_number,
-    block_timestamp,
-    tx_hash,
-    origin_function_signature,
-    origin_from_address,
-    origin_to_address,
-    contract_address,
-    pool_name,
-    event_name,
-    amount_in_unadj,
-    amount_out_unadj,
-    amount_in,
-    amount_out,
-    sender,
-    tx_to,
-    event_index,
-    platform,
-    version,
-    token_in,
-    token_out,
-    symbol_in,
-    symbol_out,
-    decimals_in,
-    decimals_out,
-    _log_id,
-    _inserted_timestamp
+    *
   FROM
-    gmx_swaps
+    gmx
   UNION ALL
   SELECT
-    block_number,
-    block_timestamp,
-    tx_hash,
-    origin_function_signature,
-    origin_from_address,
-    origin_to_address,
-    contract_address,
-    pool_name,
-    event_name,
-    amount_in_unadj,
-    amount_out_unadj,
-    amount_in,
-    amount_out,
-    sender,
-    tx_to,
-    event_index,
-    platform,
-    version,
-    token_in,
-    token_out,
-    symbol_in,
-    symbol_out,
-    decimals_in,
-    decimals_out,
-    _log_id,
-    _inserted_timestamp
+    *
   FROM
     kyberswap_v1_dynamic
   UNION ALL
   SELECT
-    block_number,
-    block_timestamp,
-    tx_hash,
-    origin_function_signature,
-    origin_from_address,
-    origin_to_address,
-    contract_address,
-    pool_name,
-    event_name,
-    amount_in_unadj,
-    amount_out_unadj,
-    amount_in,
-    amount_out,
-    sender,
-    tx_to,
-    event_index,
-    platform,
-    version,
-    token_in,
-    token_out,
-    symbol_in,
-    symbol_out,
-    decimals_in,
-    decimals_out,
-    _log_id,
-    _inserted_timestamp
+    *
   FROM
     kyberswap_v1_static
   UNION ALL
   SELECT
-    block_number,
-    block_timestamp,
-    tx_hash,
-    origin_function_signature,
-    origin_from_address,
-    origin_to_address,
-    contract_address,
-    pool_name,
-    event_name,
-    amount_in_unadj,
-    amount_out_unadj,
-    amount_in,
-    amount_out,
-    sender,
-    tx_to,
-    event_index,
-    platform,
-    version,
-    token_in,
-    token_out,
-    symbol_in,
-    symbol_out,
-    decimals_in,
-    decimals_out,
-    _log_id,
-    _inserted_timestamp
+    *
   FROM
     kyberswap_v2_elastic
   UNION ALL
   SELECT
-    block_number,
-    block_timestamp,
-    tx_hash,
-    origin_function_signature,
-    origin_from_address,
-    origin_to_address,
-    contract_address,
-    pool_name,
-    event_name,
-    amount_in_unadj,
-    amount_out_unadj,
-    amount_in,
-    amount_out,
-    sender,
-    tx_to,
-    event_index,
-    platform,
-    version,
-    token_in,
-    token_out,
-    symbol_in,
-    symbol_out,
-    decimals_in,
-    decimals_out,
-    _log_id,
-    _inserted_timestamp
+    *
   FROM
-    sushi_swaps
+    sushi
   UNION ALL
   SELECT
-    block_number,
-    block_timestamp,
-    tx_hash,
-    origin_function_signature,
-    origin_from_address,
-    origin_to_address,
-    contract_address,
-    pool_name,
-    event_name,
-    amount_in_unadj,
-    amount_out_unadj,
-    amount_in,
-    amount_out,
-    sender,
-    tx_to,
-    event_index,
-    platform,
-    version,
-    token_in,
-    token_out,
-    symbol_in,
-    symbol_out,
-    decimals_in,
-    decimals_out,
-    _log_id,
-    _inserted_timestamp
+    *
   FROM
-    univ2_swaps
+    univ2
   UNION ALL
   SELECT
-    block_number,
-    block_timestamp,
-    tx_hash,
-    origin_function_signature,
-    origin_from_address,
-    origin_to_address,
-    contract_address,
-    pool_name,
-    event_name,
-    amount_in_unadj,
-    amount_out_unadj,
-    amount_in,
-    amount_out,
-    sender,
-    tx_to,
-    event_index,
-    platform,
-    version,
-    token_in,
-    token_out,
-    symbol_in,
-    symbol_out,
-    decimals_in,
-    decimals_out,
-    _log_id,
-    _inserted_timestamp
+    *
   FROM
-    sparta_swaps
+    sparta
   UNION ALL
   SELECT
-    block_number,
-    block_timestamp,
-    tx_hash,
-    origin_function_signature,
-    origin_from_address,
-    origin_to_address,
-    contract_address,
-    pool_name,
-    event_name,
-    amount_in_unadj,
-    amount_out_unadj,
-    amount_in,
-    amount_out,
-    sender,
-    tx_to,
-    event_index,
-    platform,
-    version,
-    token_in,
-    token_out,
-    symbol_in,
-    symbol_out,
-    decimals_in,
-    decimals_out,
-    _log_id,
-    _inserted_timestamp
+    *
   FROM
-    trader_joe_v1_swaps
+    trader_joe_v1
   UNION ALL
   SELECT
-    block_number,
-    block_timestamp,
-    tx_hash,
-    origin_function_signature,
-    origin_from_address,
-    origin_to_address,
-    contract_address,
-    pool_name,
-    event_name,
-    amount_in_unadj,
-    amount_out_unadj,
-    amount_in,
-    amount_out,
-    sender,
-    tx_to,
-    event_index,
-    platform,
-    version,
-    token_in,
-    token_out,
-    symbol_in,
-    symbol_out,
-    decimals_in,
-    decimals_out,
-    _log_id,
-    _inserted_timestamp
+    *
   FROM
-    trader_joe_v2_1_swaps
+    trader_joe_v2_1
   UNION ALL
   SELECT
-    block_number,
-    block_timestamp,
-    tx_hash,
-    origin_function_signature,
-    origin_from_address,
-    origin_to_address,
-    contract_address,
-    pool_name,
-    event_name,
-    amount_in_unadj,
-    amount_out_unadj,
-    amount_in,
-    amount_out,
-    sender,
-    tx_to,
-    event_index,
-    platform,
-    version,
-    token_in,
-    token_out,
-    symbol_in,
-    symbol_out,
-    decimals_in,
-    decimals_out,
-    _log_id,
-    _inserted_timestamp
+    *
   FROM
-    trader_joe_v2_swaps
+    trader_joe_v2
   UNION ALL
   SELECT
-    block_number,
-    block_timestamp,
-    tx_hash,
-    origin_function_signature,
-    origin_from_address,
-    origin_to_address,
-    contract_address,
-    pool_name,
-    event_name,
-    amount_in_unadj,
-    amount_out_unadj,
-    amount_in,
-    amount_out,
-    sender,
-    tx_to,
-    event_index,
-    platform,
-    version,
-    token_in,
-    token_out,
-    symbol_in,
-    symbol_out,
-    decimals_in,
-    decimals_out,
-    _log_id,
-    _inserted_timestamp
+    *
   FROM
-    woofi_swaps
+    woofi
   UNION ALL
   SELECT
-    block_number,
-    block_timestamp,
-    tx_hash,
-    origin_function_signature,
-    origin_from_address,
-    origin_to_address,
-    contract_address,
-    pool_name,
-    event_name,
-    amount_in_unadj,
-    amount_out_unadj,
-    amount_in,
-    amount_out,
-    sender,
-    tx_to,
-    event_index,
-    platform,
-    version,
-    token_in,
-    token_out,
-    symbol_in,
-    symbol_out,
-    decimals_in,
-    decimals_out,
-    _log_id,
-    _inserted_timestamp
+    *
   FROM
-    zyberswap_v2_swaps
+    zyberswap_v2
   UNION ALL
   SELECT
-    block_number,
-    block_timestamp,
-    tx_hash,
-    origin_function_signature,
-    origin_from_address,
-    origin_to_address,
-    contract_address,
-    pool_name,
-    event_name,
-    amount_in_unadj,
-    amount_out_unadj,
-    amount_in,
-    amount_out,
-    sender,
-    tx_to,
-    event_index,
-    platform,
-    version,
-    token_in,
-    token_out,
-    symbol_in,
-    symbol_out,
-    decimals_in,
-    decimals_out,
-    _log_id,
-    _inserted_timestamp
+    *
   FROM
-    zyberswap_v3_swaps
+    zyberswap_v3
+  UNION ALL
+  SELECT
+    *
+  FROM
+    univ3
+  UNION ALL
+  SELECT
+    *
+  FROM
+    ramses_v2
 ),
---union all non-standard dex CTEs here (excludes amount_usd)
-all_dex_custom AS (
+complete_dex_swaps AS (
   SELECT
-    block_number,
-    block_timestamp,
-    tx_hash,
+    s.block_number,
+    s.block_timestamp,
+    s.tx_hash,
     origin_function_signature,
     origin_from_address,
     origin_to_address,
-    contract_address,
-    pool_name,
+    s.contract_address,
     event_name,
-    amount_in_unadj,
-    amount_in,
-    amount_in_usd,
-    amount_out_unadj,
-    amount_out,
-    amount_out_usd,
-    sender,
-    tx_to,
-    event_index,
-    platform,
-    version,
     token_in,
-    token_out,
-    symbol_in,
-    symbol_out,
-    _log_id,
-    _inserted_timestamp
-  FROM
-    univ3_swaps
-  UNION ALL
-  SELECT
-    block_number,
-    block_timestamp,
-    tx_hash,
-    origin_function_signature,
-    origin_from_address,
-    origin_to_address,
-    contract_address,
-    pool_name,
-    event_name,
+    c1.token_decimals AS decimals_in,
+    c1.token_symbol AS symbol_in,
     amount_in_unadj,
-    amount_in,
-    amount_in_usd,
-    amount_out_unadj,
-    amount_out,
-    amount_out_usd,
-    sender,
-    tx_to,
-    event_index,
-    platform,
-    version,
-    token_in,
-    token_out,
-    symbol_in,
-    symbol_out,
-    _log_id,
-    _inserted_timestamp
-  FROM
-    ramses_v2_swaps
-),
-FINAL AS (
-  SELECT
-    block_number,
-    block_timestamp,
-    tx_hash,
-    origin_function_signature,
-    origin_from_address,
-    origin_to_address,
-    contract_address,
-    pool_name,
-    event_name,
-    amount_in_unadj,
-    amount_in,
     CASE
-      WHEN s.decimals_in IS NOT NULL THEN ROUND(
-        amount_in * p1.price,
-        2
-      )
+      WHEN decimals_in IS NULL THEN amount_in_unadj
+      ELSE (amount_in_unadj / pow(10, decimals_in))
+    END AS amount_in,
+    CASE
+      WHEN decimals_in IS NOT NULL THEN amount_in * p1.price
       ELSE NULL
     END AS amount_in_usd,
+    token_out,
+    c2.token_decimals AS decimals_out,
+    c2.token_symbol AS symbol_out,
     amount_out_unadj,
-    amount_out,
     CASE
-      WHEN s.decimals_out IS NOT NULL THEN ROUND(
-        amount_out * p2.price,
-        2
-      )
+      WHEN decimals_out IS NULL THEN amount_out_unadj
+      ELSE (amount_out_unadj / pow(10, decimals_out))
+    END AS amount_out,
+    CASE
+      WHEN decimals_out IS NOT NULL THEN amount_out * p2.price
       ELSE NULL
     END AS amount_out_usd,
+    CASE
+      WHEN lp.pool_name IS NULL THEN CONCAT(
+        LEAST(
+          COALESCE(
+            symbol_in,
+            CONCAT(SUBSTRING(token_in, 1, 5), '...', SUBSTRING(token_in, 39, 42))
+          ),
+          COALESCE(
+            symbol_out,
+            CONCAT(SUBSTRING(token_out, 1, 5), '...', SUBSTRING(token_out, 39, 42))
+          )
+        ),
+        '-',
+        GREATEST(
+          COALESCE(
+            symbol_in,
+            CONCAT(SUBSTRING(token_in, 1, 5), '...', SUBSTRING(token_in, 39, 42))
+          ),
+          COALESCE(
+            symbol_out,
+            CONCAT(SUBSTRING(token_out, 1, 5), '...', SUBSTRING(token_out, 39, 42))
+          )
+        )
+      )
+      ELSE lp.pool_name
+    END AS pool_name,
     sender,
     tx_to,
     event_index,
-    platform,
-    version,
-    token_in,
-    token_out,
-    symbol_in,
-    symbol_out,
-    _log_id,
-    _inserted_timestamp
+    s.platform,
+    s.version,
+    s._log_id,
+    s._inserted_timestamp
   FROM
-    all_dex_standard s
-    LEFT JOIN prices p1
+    all_dex s
+    LEFT JOIN {{ ref('silver__contracts') }}
+    c1
+    ON s.token_in = c1.contract_address
+    LEFT JOIN {{ ref('silver__contracts') }}
+    c2
+    ON s.token_out = c2.contract_address
+    LEFT JOIN {{ ref('price__ez_prices_hourly') }}
+    p1
     ON s.token_in = p1.token_address
     AND DATE_TRUNC(
       'hour',
       block_timestamp
     ) = p1.hour
-    LEFT JOIN prices p2
+    LEFT JOIN {{ ref('price__ez_prices_hourly') }}
+    p2
     ON s.token_out = p2.token_address
     AND DATE_TRUNC(
       'hour',
       block_timestamp
     ) = p2.hour
-  UNION ALL
+    LEFT JOIN {{ ref('silver_dex__complete_dex_liquidity_pools') }}
+    lp
+    ON s.contract_address = lp.pool_address
+),
+
+{% if is_incremental() and var(
+  'HEAL_MODEL'
+) %}
+heal_model AS (
   SELECT
-    block_number,
-    block_timestamp,
-    tx_hash,
+    t0.block_number,
+    t0.block_timestamp,
+    t0.tx_hash,
     origin_function_signature,
     origin_from_address,
     origin_to_address,
-    contract_address,
-    pool_name,
+    t0.contract_address,
     event_name,
+    token_in,
+    c1.token_decimals AS decimals_in,
+    c1.token_symbol AS symbol_in,
     amount_in_unadj,
-    amount_in,
-    ROUND(
-      amount_in_usd,
-      2
-    ) AS amount_in_usd,
+    CASE
+      WHEN c1.token_decimals IS NULL THEN amount_in_unadj
+      ELSE (amount_in_unadj / pow(10, c1.token_decimals))
+    END AS amount_in_heal,
+    CASE
+      WHEN c1.token_decimals IS NOT NULL THEN amount_in_heal * p1.price
+      ELSE NULL
+    END AS amount_in_usd_heal,
+    token_out,
+    c2.token_decimals AS decimals_out,
+    c2.token_symbol AS symbol_out,
     amount_out_unadj,
-    amount_out,
-    ROUND(
-      amount_out_usd,
-      2
-    ) AS amount_out_usd,
+    CASE
+      WHEN c2.token_decimals IS NULL THEN amount_out_unadj
+      ELSE (amount_out_unadj / pow(10, c2.token_decimals))
+    END AS amount_out_heal,
+    CASE
+      WHEN c2.token_decimals IS NOT NULL THEN amount_out_heal * p2.price
+      ELSE NULL
+    END AS amount_out_usd_heal,
+    CASE
+      WHEN lp.pool_name IS NULL THEN CONCAT(
+        LEAST(
+          COALESCE(
+            c1.token_symbol,
+            CONCAT(SUBSTRING(token_in, 1, 5), '...', SUBSTRING(token_in, 39, 42))
+          ),
+          COALESCE(
+            c2.token_symbol,
+            CONCAT(SUBSTRING(token_out, 1, 5), '...', SUBSTRING(token_out, 39, 42))
+          )
+        ),
+        '-',
+        GREATEST(
+          COALESCE(
+            c1.token_symbol,
+            CONCAT(SUBSTRING(token_in, 1, 5), '...', SUBSTRING(token_in, 39, 42))
+          ),
+          COALESCE(
+            c2.token_symbol,
+            CONCAT(SUBSTRING(token_out, 1, 5), '...', SUBSTRING(token_out, 39, 42))
+          )
+        )
+      )
+      ELSE lp.pool_name
+    END AS pool_name_heal,
     sender,
     tx_to,
     event_index,
-    platform,
-    version,
-    token_in,
-    token_out,
-    symbol_in,
-    symbol_out,
-    _log_id,
-    _inserted_timestamp
+    t0.platform,
+    t0.version,
+    t0._log_id,
+    t0._inserted_timestamp
   FROM
-    all_dex_custom C
-)
+    {{ this }}
+    t0
+    LEFT JOIN {{ ref('silver__contracts') }}
+    c1
+    ON t0.token_in = c1.contract_address
+    LEFT JOIN {{ ref('silver__contracts') }}
+    c2
+    ON t0.token_out = c2.contract_address
+    LEFT JOIN {{ ref('price__ez_prices_hourly') }}
+    p1
+    ON t0.token_in = p1.token_address
+    AND DATE_TRUNC(
+      'hour',
+      block_timestamp
+    ) = p1.hour
+    LEFT JOIN {{ ref('price__ez_prices_hourly') }}
+    p2
+    ON t0.token_out = p2.token_address
+    AND DATE_TRUNC(
+      'hour',
+      block_timestamp
+    ) = p2.hour
+    LEFT JOIN {{ ref('silver_dex__complete_dex_liquidity_pools') }}
+    lp
+    ON t0.contract_address = lp.pool_address
+  WHERE
+    CONCAT(
+      t0.block_number,
+      '-',
+      t0.platform,
+      '-',
+      t0.version
+    ) IN (
+      SELECT
+        CONCAT(
+          t1.block_number,
+          '-',
+          t1.platform,
+          '-',
+          t1.version
+        )
+      FROM
+        {{ this }}
+        t1
+      WHERE
+        t1.decimals_in IS NULL
+        AND t1._inserted_timestamp < (
+          SELECT
+            MAX(
+              _inserted_timestamp
+            ) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
+          FROM
+            {{ this }}
+        )
+        AND EXISTS (
+          SELECT
+            1
+          FROM
+            {{ ref('silver__contracts') }} C
+          WHERE
+            C._inserted_timestamp > DATEADD('DAY', -14, SYSDATE())
+            AND C.token_decimals IS NOT NULL
+            AND C.contract_address = t1.token_in)
+          GROUP BY
+            1
+        )
+        OR CONCAT(
+          t0.block_number,
+          '-',
+          t0.platform,
+          '-',
+          t0.version
+        ) IN (
+          SELECT
+            CONCAT(
+              t2.block_number,
+              '-',
+              t2.platform,
+              '-',
+              t2.version
+            )
+          FROM
+            {{ this }}
+            t2
+          WHERE
+            t2.decimals_out IS NULL
+            AND t2._inserted_timestamp < (
+              SELECT
+                MAX(
+                  _inserted_timestamp
+                ) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
+              FROM
+                {{ this }}
+            )
+            AND EXISTS (
+              SELECT
+                1
+              FROM
+                {{ ref('silver__contracts') }} C
+              WHERE
+                C._inserted_timestamp > DATEADD('DAY', -14, SYSDATE())
+                AND C.token_decimals IS NOT NULL
+                AND C.contract_address = t2.token_out)
+              GROUP BY
+                1
+            )
+            OR CONCAT(
+              t0.block_number,
+              '-',
+              t0.platform,
+              '-',
+              t0.version
+            ) IN (
+              SELECT
+                CONCAT(
+                  t3.block_number,
+                  '-',
+                  t3.platform,
+                  '-',
+                  t3.version
+                )
+              FROM
+                {{ this }}
+                t3
+              WHERE
+                t3.amount_in_usd IS NULL
+                AND t3._inserted_timestamp < (
+                  SELECT
+                    MAX(
+                      _inserted_timestamp
+                    ) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
+                  FROM
+                    {{ this }}
+                )
+                AND EXISTS (
+                  SELECT
+                    1
+                  FROM
+                    {{ ref('silver__complete_token_prices') }}
+                    p
+                  WHERE
+                    p._inserted_timestamp > DATEADD('DAY', -14, SYSDATE())
+                    AND p.price IS NOT NULL
+                    AND p.token_address = t3.token_in
+                    AND p.hour = DATE_TRUNC(
+                      'hour',
+                      t3.block_timestamp
+                    )
+                )
+              GROUP BY
+                1
+            )
+            OR CONCAT(
+              t0.block_number,
+              '-',
+              t0.platform,
+              '-',
+              t0.version
+            ) IN (
+              SELECT
+                CONCAT(
+                  t4.block_number,
+                  '-',
+                  t4.platform,
+                  '-',
+                  t4.version
+                )
+              FROM
+                {{ this }}
+                t4
+              WHERE
+                t4.amount_out_usd IS NULL
+                AND t4._inserted_timestamp < (
+                  SELECT
+                    MAX(
+                      _inserted_timestamp
+                    ) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
+                  FROM
+                    {{ this }}
+                )
+                AND EXISTS (
+                  SELECT
+                    1
+                  FROM
+                    {{ ref('silver__complete_token_prices') }}
+                    p
+                  WHERE
+                    p._inserted_timestamp > DATEADD('DAY', -14, SYSDATE())
+                    AND p.price IS NOT NULL
+                    AND p.token_address = t4.token_out
+                    AND p.hour = DATE_TRUNC(
+                      'hour',
+                      t4.block_timestamp
+                    )
+                )
+              GROUP BY
+                1
+            )
+        ),
+      {% endif %}
+
+      FINAL AS (
+        SELECT
+          *
+        FROM
+          complete_dex_swaps
+
+{% if is_incremental() and var(
+  'HEAL_MODEL'
+) %}
+UNION ALL
 SELECT
-  f.block_number,
-  f.block_timestamp,
-  f.tx_hash,
+  block_number,
+  block_timestamp,
+  tx_hash,
   origin_function_signature,
   origin_from_address,
   origin_to_address,
-  f.contract_address,
-  CASE
-    WHEN f.pool_name IS NULL THEN p.pool_name
-    ELSE f.pool_name
-  END AS pool_name,
+  contract_address,
   event_name,
+  token_in,
+  decimals_in,
+  symbol_in,
   amount_in_unadj,
-  amount_in,
-  CASE
-    WHEN amount_out_usd IS NULL
-    OR ABS((amount_in_usd - amount_out_usd) / NULLIF(amount_out_usd, 0)) > 0.75
-    OR ABS((amount_in_usd - amount_out_usd) / NULLIF(amount_in_usd, 0)) > 0.75 THEN NULL
-    ELSE amount_in_usd
-  END AS amount_in_usd,
+  amount_in_heal AS amount_in,
+  amount_in_usd_heal AS amount_in_usd,
+  token_out,
+  decimals_out,
+  symbol_out,
   amount_out_unadj,
-  amount_out,
-  CASE
-    WHEN amount_in_usd IS NULL
-    OR ABS((amount_out_usd - amount_in_usd) / NULLIF(amount_in_usd, 0)) > 0.75
-    OR ABS((amount_out_usd - amount_in_usd) / NULLIF(amount_out_usd, 0)) > 0.75 THEN NULL
-    ELSE amount_out_usd
-  END AS amount_out_usd,
+  amount_out_heal AS amount_out,
+  amount_out_usd_heal AS amount_out_usd,
+  pool_name_heal AS pool_name,
   sender,
   tx_to,
   event_index,
-  f.platform,
-  f.version,
+  platform,
+  version,
+  _log_id,
+  _inserted_timestamp
+FROM
+  heal_model
+{% endif %}
+)
+SELECT
+  block_number,
+  block_timestamp,
+  tx_hash,
+  origin_function_signature,
+  origin_from_address,
+  origin_to_address,
+  contract_address,
+  pool_name,
+  event_name,
+  amount_in_unadj,
+  amount_in,
+  amount_in_usd,
+  amount_out_unadj,
+  amount_out,
+  amount_out_usd,
+  sender,
+  tx_to,
+  event_index,
+  platform,
+  version,
   token_in,
   token_out,
   symbol_in,
   symbol_out,
-  f._log_id,
-  f._inserted_timestamp,
+  decimals_in,
+  decimals_out,
+  _log_id,
+  _inserted_timestamp,
   {{ dbt_utils.generate_surrogate_key(
-    ['f.tx_hash','f.event_index']
+    ['tx_hash','event_index']
   ) }} AS complete_dex_swaps_id,
   SYSDATE() AS inserted_timestamp,
   SYSDATE() AS modified_timestamp,
   '{{ invocation_id }}' AS _invocation_id
 FROM
-  FINAL f
-LEFT JOIN {{ ref('silver_dex__complete_dex_liquidity_pools') }} p
-  ON f.contract_address = p.pool_address
+  FINAL qualify (ROW_NUMBER() over (PARTITION BY _log_id
+ORDER BY
+  _inserted_timestamp DESC)) = 1

--- a/models/silver/defi/dex/silver_dex__complete_dex_swaps.sql
+++ b/models/silver/defi/dex/silver_dex__complete_dex_swaps.sql
@@ -128,7 +128,7 @@ ramses_v2_swaps AS (
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
+      MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
     FROM
       {{ this }}
   )
@@ -230,7 +230,7 @@ univ3_swaps AS (
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
+      MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
     FROM
       {{ this }}
   )
@@ -282,7 +282,7 @@ balancer_swaps AS (
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
+      MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
     FROM
       {{ this }}
   )
@@ -351,7 +351,7 @@ curve_swaps AS (
 {% if is_incremental() and 'curve_swaps' not in var('HEAL_MODELS') %}
 AND _inserted_timestamp >= (
   SELECT
-    MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
+    MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
   FROM
     {{ this }}
 )
@@ -403,7 +403,7 @@ trader_joe_v1_swaps AS (
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
+      MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
     FROM
       {{ this }}
   )
@@ -455,7 +455,7 @@ trader_joe_v2_swaps AS (
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
+      MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
     FROM
       {{ this }}
   )
@@ -507,7 +507,7 @@ trader_joe_v2_1_swaps AS (
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
+      MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
     FROM
       {{ this }}
   )
@@ -569,7 +569,7 @@ woofi_swaps AS (
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
+      MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
     FROM
       {{ this }}
   )
@@ -631,7 +631,7 @@ hashflow_swaps AS (
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
+      MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
     FROM
       {{ this }}
   )
@@ -693,7 +693,7 @@ hashflow_v3_swaps AS (
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
+      MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
     FROM
       {{ this }}
   )
@@ -755,7 +755,7 @@ gmx_swaps AS (
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
+      MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
     FROM
       {{ this }}
   )
@@ -807,7 +807,7 @@ kyberswap_v1_dynamic AS (
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
+      MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
     FROM
       {{ this }}
   )
@@ -859,7 +859,7 @@ kyberswap_v1_static AS (
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
+      MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
     FROM
       {{ this }}
   )
@@ -911,7 +911,7 @@ kyberswap_v2_elastic AS (
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
+      MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
     FROM
       {{ this }}
   )
@@ -963,7 +963,7 @@ fraxswap_swaps AS (
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
+      MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
     FROM
       {{ this }}
   )
@@ -1015,7 +1015,7 @@ sushi_swaps AS (
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
+      MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
     FROM
       {{ this }}
   )
@@ -1067,7 +1067,7 @@ univ2_swaps AS (
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
+      MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
     FROM
       {{ this }}
   )
@@ -1119,7 +1119,7 @@ sparta_swaps AS (
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
+      MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
     FROM
       {{ this }}
   )
@@ -1171,7 +1171,7 @@ dodo_v1_swaps AS (
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
+      MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
     FROM
       {{ this }}
   )
@@ -1223,7 +1223,7 @@ dodo_v2_swaps AS (
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
+      MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
     FROM
       {{ this }}
   )
@@ -1275,7 +1275,7 @@ camelot_v2_swaps AS (
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
+      MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
     FROM
       {{ this }}
   )
@@ -1327,7 +1327,7 @@ camelot_v3_swaps AS (
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
+      MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
     FROM
       {{ this }}
   )
@@ -1379,7 +1379,7 @@ zyberswap_v2_swaps AS (
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
+      MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
     FROM
       {{ this }}
   )
@@ -1431,7 +1431,7 @@ zyberswap_v3_swaps AS (
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
+      MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
     FROM
       {{ this }}
   )

--- a/models/silver/defi/dex/silver_dex__complete_dex_swaps.sql
+++ b/models/silver/defi/dex/silver_dex__complete_dex_swaps.sql
@@ -1,9 +1,10 @@
+-- depends_on: {{ ref('silver__complete_token_prices') }}
 {{ config(
   materialized = 'incremental',
   incremental_strategy = 'delete+insert',
   unique_key = ['block_number','platform','version'],
   cluster_by = ['block_timestamp::DATE'],
-  tags = ['curated','reorg']
+  tags = ['curated','reorg','heal']
 ) }}
 
 WITH contracts AS (
@@ -123,11 +124,11 @@ ramses_v2_swaps AS (
       block_timestamp
     ) = p2.hour
 
-{% if is_incremental() and 'ramses_v2_swaps' not in var('HEAL_CURATED_MODEL') %}
+{% if is_incremental() and 'ramses_v2_swaps' not in var('HEAL_MODELS') %}
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) - INTERVAL '36 hours'
+      MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
     FROM
       {{ this }}
   )
@@ -225,11 +226,11 @@ univ3_swaps AS (
       block_timestamp
     ) = p2.hour
 
-{% if is_incremental() and 'univ3_swaps' not in var('HEAL_CURATED_MODEL') %}
+{% if is_incremental() and 'univ3_swaps' not in var('HEAL_MODELS') %}
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) - INTERVAL '36 hours'
+      MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
     FROM
       {{ this }}
   )
@@ -277,11 +278,11 @@ balancer_swaps AS (
     LEFT JOIN contracts c2
     ON s.token_out = c2.address
 
-{% if is_incremental() and 'balancer_swaps' not in var('HEAL_CURATED_MODEL') %}
+{% if is_incremental() and 'balancer_swaps' not in var('HEAL_MODELS') %}
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) - INTERVAL '36 hours'
+      MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
     FROM
       {{ this }}
   )
@@ -347,10 +348,10 @@ curve_swaps AS (
       'null'
     ) <> COALESCE(token_symbol_out, 'null')
 
-{% if is_incremental() and 'curve_swaps' not in var('HEAL_CURATED_MODEL') %}
+{% if is_incremental() and 'curve_swaps' not in var('HEAL_MODELS') %}
 AND _inserted_timestamp >= (
   SELECT
-    MAX(_inserted_timestamp) - INTERVAL '12 hours'
+    MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
   FROM
     {{ this }}
 )
@@ -398,11 +399,11 @@ trader_joe_v1_swaps AS (
     LEFT JOIN contracts c2
     ON s.token_out = c2.address
 
-{% if is_incremental() and 'trader_joe_v1_swaps' not in var('HEAL_CURATED_MODEL') %}
+{% if is_incremental() and 'trader_joe_v1_swaps' not in var('HEAL_MODELS') %}
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) - INTERVAL '36 hours'
+      MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
     FROM
       {{ this }}
   )
@@ -450,11 +451,11 @@ trader_joe_v2_swaps AS (
     LEFT JOIN contracts c2
     ON s.token_out = c2.address
 
-{% if is_incremental() and 'trader_joe_v2_swaps' not in var('HEAL_CURATED_MODEL') %}
+{% if is_incremental() and 'trader_joe_v2_swaps' not in var('HEAL_MODELS') %}
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) - INTERVAL '36 hours'
+      MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
     FROM
       {{ this }}
   )
@@ -502,11 +503,11 @@ trader_joe_v2_1_swaps AS (
     LEFT JOIN contracts c2
     ON s.token_out = c2.address
 
-{% if is_incremental() and 'trader_joe_v2_1_swaps' not in var('HEAL_CURATED_MODEL') %}
+{% if is_incremental() and 'trader_joe_v2_1_swaps' not in var('HEAL_MODELS') %}
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) - INTERVAL '36 hours'
+      MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
     FROM
       {{ this }}
   )
@@ -564,11 +565,11 @@ woofi_swaps AS (
     LEFT JOIN contracts c2
     ON s.token_out = c2.address
 
-{% if is_incremental() and 'woofi_swaps' not in var('HEAL_CURATED_MODEL') %}
+{% if is_incremental() and 'woofi_swaps' not in var('HEAL_MODELS') %}
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) - INTERVAL '36 hours'
+      MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
     FROM
       {{ this }}
   )
@@ -626,11 +627,11 @@ hashflow_swaps AS (
     LEFT JOIN contracts c2
     ON s.token_out = c2.address
 
-{% if is_incremental() and 'hashflow_swaps' not in var('HEAL_CURATED_MODEL') %}
+{% if is_incremental() and 'hashflow_swaps' not in var('HEAL_MODELS') %}
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) - INTERVAL '36 hours'
+      MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
     FROM
       {{ this }}
   )
@@ -688,11 +689,11 @@ hashflow_v3_swaps AS (
     LEFT JOIN contracts c2
     ON s.token_out = c2.address
 
-{% if is_incremental() and 'hashflow_v3_swaps' not in var('HEAL_CURATED_MODEL') %}
+{% if is_incremental() and 'hashflow_v3_swaps' not in var('HEAL_MODELS') %}
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) - INTERVAL '36 hours'
+      MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
     FROM
       {{ this }}
   )
@@ -750,11 +751,11 @@ gmx_swaps AS (
     LEFT JOIN contracts c2
     ON s.token_out = c2.address
 
-{% if is_incremental() and 'gmx_swaps' not in var('HEAL_CURATED_MODEL') %}
+{% if is_incremental() and 'gmx_swaps' not in var('HEAL_MODELS') %}
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) - INTERVAL '36 hours'
+      MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
     FROM
       {{ this }}
   )
@@ -802,11 +803,11 @@ kyberswap_v1_dynamic AS (
     LEFT JOIN contracts c2
     ON s.token_out = c2.address
 
-{% if is_incremental() and 'kyberswap_v1_dynamic' not in var('HEAL_CURATED_MODEL') %}
+{% if is_incremental() and 'kyberswap_v1_dynamic' not in var('HEAL_MODELS') %}
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) - INTERVAL '36 hours'
+      MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
     FROM
       {{ this }}
   )
@@ -854,11 +855,11 @@ kyberswap_v1_static AS (
     LEFT JOIN contracts c2
     ON s.token_out = c2.address
 
-{% if is_incremental() and 'kyberswap_v1_static' not in var('HEAL_CURATED_MODEL') %}
+{% if is_incremental() and 'kyberswap_v1_static' not in var('HEAL_MODELS') %}
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) - INTERVAL '36 hours'
+      MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
     FROM
       {{ this }}
   )
@@ -906,11 +907,11 @@ kyberswap_v2_elastic AS (
     LEFT JOIN contracts c2
     ON s.token_out = c2.address
 
-{% if is_incremental() and 'kyberswap_v2_elastic' not in var('HEAL_CURATED_MODEL') %}
+{% if is_incremental() and 'kyberswap_v2_elastic' not in var('HEAL_MODELS') %}
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) - INTERVAL '36 hours'
+      MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
     FROM
       {{ this }}
   )
@@ -958,11 +959,11 @@ fraxswap_swaps AS (
     LEFT JOIN contracts c2
     ON s.token_out = c2.address
 
-{% if is_incremental() and 'fraxswap_swaps' not in var('HEAL_CURATED_MODEL') %}
+{% if is_incremental() and 'fraxswap_swaps' not in var('HEAL_MODELS') %}
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) - INTERVAL '36 hours'
+      MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
     FROM
       {{ this }}
   )
@@ -1010,11 +1011,11 @@ sushi_swaps AS (
     LEFT JOIN contracts c2
     ON s.token_out = c2.address
 
-{% if is_incremental() and 'sushi_swaps' not in var('HEAL_CURATED_MODEL') %}
+{% if is_incremental() and 'sushi_swaps' not in var('HEAL_MODELS') %}
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) - INTERVAL '36 hours'
+      MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
     FROM
       {{ this }}
   )
@@ -1062,11 +1063,11 @@ univ2_swaps AS (
     LEFT JOIN contracts c2
     ON s.token_out = c2.address
 
-{% if is_incremental() and 'univ2_swaps' not in var('HEAL_CURATED_MODEL') %}
+{% if is_incremental() and 'univ2_swaps' not in var('HEAL_MODELS') %}
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) - INTERVAL '36 hours'
+      MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
     FROM
       {{ this }}
   )
@@ -1114,11 +1115,11 @@ sparta_swaps AS (
     LEFT JOIN contracts c2
     ON s.token_out = c2.address
 
-{% if is_incremental() and 'sparta_swaps' not in var('HEAL_CURATED_MODEL') %}
+{% if is_incremental() and 'sparta_swaps' not in var('HEAL_MODELS') %}
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) - INTERVAL '36 hours'
+      MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
     FROM
       {{ this }}
   )
@@ -1166,11 +1167,11 @@ dodo_v1_swaps AS (
     LEFT JOIN contracts c2
     ON s.token_out = c2.address
 
-{% if is_incremental() and 'dodo_v1_swaps' not in var('HEAL_CURATED_MODEL') %}
+{% if is_incremental() and 'dodo_v1_swaps' not in var('HEAL_MODELS') %}
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) - INTERVAL '36 hours'
+      MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
     FROM
       {{ this }}
   )
@@ -1218,11 +1219,11 @@ dodo_v2_swaps AS (
     LEFT JOIN contracts c2
     ON s.token_out = c2.address
 
-{% if is_incremental() and 'dodo_v2_swaps' not in var('HEAL_CURATED_MODEL') %}
+{% if is_incremental() and 'dodo_v2_swaps' not in var('HEAL_MODELS') %}
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) - INTERVAL '36 hours'
+      MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
     FROM
       {{ this }}
   )
@@ -1270,11 +1271,11 @@ camelot_v2_swaps AS (
     LEFT JOIN contracts c2
     ON s.token_out = c2.address
 
-{% if is_incremental() and 'camelot_v2_swaps' not in var('HEAL_CURATED_MODEL') %}
+{% if is_incremental() and 'camelot_v2_swaps' not in var('HEAL_MODELS') %}
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) - INTERVAL '36 hours'
+      MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
     FROM
       {{ this }}
   )
@@ -1322,11 +1323,11 @@ camelot_v3_swaps AS (
     LEFT JOIN contracts c2
     ON s.token_out = c2.address
 
-{% if is_incremental() and 'camelot_v3_swaps' not in var('HEAL_CURATED_MODEL') %}
+{% if is_incremental() and 'camelot_v3_swaps' not in var('HEAL_MODELS') %}
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) - INTERVAL '36 hours'
+      MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
     FROM
       {{ this }}
   )
@@ -1374,11 +1375,11 @@ zyberswap_v2_swaps AS (
     LEFT JOIN contracts c2
     ON s.token_out = c2.address
 
-{% if is_incremental() and 'zyberswap_v2_swaps' not in var('HEAL_CURATED_MODEL') %}
+{% if is_incremental() and 'zyberswap_v2_swaps' not in var('HEAL_MODELS') %}
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) - INTERVAL '36 hours'
+      MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
     FROM
       {{ this }}
   )
@@ -1426,11 +1427,11 @@ zyberswap_v3_swaps AS (
     LEFT JOIN contracts c2
     ON s.token_out = c2.address
 
-{% if is_incremental() and 'zyberswap_v3_swaps' not in var('HEAL_CURATED_MODEL') %}
+{% if is_incremental() and 'zyberswap_v3_swaps' not in var('HEAL_MODELS') %}
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) - INTERVAL '36 hours'
+      MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
     FROM
       {{ this }}
   )

--- a/models/silver/defi/dex/silver_dex__complete_dex_swaps.sql
+++ b/models/silver/defi/dex/silver_dex__complete_dex_swaps.sql
@@ -159,12 +159,13 @@ curve AS (
     {{ ref('silver_dex__curve_swaps') }}
 
 {% if is_incremental() and 'curve' not in var('HEAL_MODELS') %}
-AND _inserted_timestamp >= (
-  SELECT
-    MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
-  FROM
-    {{ this }}
-)
+WHERE
+  _inserted_timestamp >= (
+    SELECT
+      MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
+    FROM
+      {{ this }}
+  )
 {% endif %}
 ),
 trader_joe_v1 AS (
@@ -427,7 +428,7 @@ kyberswap_v1_dynamic AS (
     _log_id,
     _inserted_timestamp
   FROM
-    {{ ref('silver_dex__kyberswap_v1_dynamic') }}
+    {{ ref('silver_dex__kyberswap_v1_dynamic_swaps') }}
 
 {% if is_incremental() and 'kyberswap_v1_dynamic' not in var('HEAL_MODELS') %}
 WHERE

--- a/models/silver/defi/dex/sparta/silver_dex__sparta_pools.sql
+++ b/models/silver/defi/dex/sparta/silver_dex__sparta_pools.sql
@@ -27,6 +27,7 @@ WITH pool_creation AS (
     WHERE
         contract_address = LOWER('0xFe8EC10Fe07A6a6f4A2584f8cD9FE232930eAF55')
         AND topics [0] :: STRING = '0x0d3648bd0f6ba80134a33ba9275ac585d9d315f0ad8355cddefde31afa28d0e9' --PairCreated
+        AND tx_status = 'SUCCESS'
 
 {% if is_incremental() %}
 AND _inserted_timestamp >= (

--- a/models/silver/defi/dex/sushi/silver_dex__sushi_pools.sql
+++ b/models/silver/defi/dex/sushi/silver_dex__sushi_pools.sql
@@ -27,6 +27,7 @@ WITH pool_creation AS (
     WHERE
         contract_address = LOWER('0xc35DADB65012eC5796536bD9864eD8773aBc74C4')
         AND topics [0] :: STRING = '0x0d3648bd0f6ba80134a33ba9275ac585d9d315f0ad8355cddefde31afa28d0e9' --PairCreated
+        AND tx_status = 'SUCCESS'
 
 {% if is_incremental() %}
 AND _inserted_timestamp >= (

--- a/models/silver/defi/dex/trader_joe/silver_dex__trader_joe_v1_pools.sql
+++ b/models/silver/defi/dex/trader_joe/silver_dex__trader_joe_v1_pools.sql
@@ -27,6 +27,7 @@ WITH pool_creation AS (
     WHERE
         contract_address = LOWER('0xae4ec9901c3076d0ddbe76a520f9e90a6227acb7')
         AND topics [0] :: STRING = '0x0d3648bd0f6ba80134a33ba9275ac585d9d315f0ad8355cddefde31afa28d0e9' --PairCreated
+        AND tx_status = 'SUCCESS'
 
 {% if is_incremental() %}
 AND _inserted_timestamp >= (

--- a/models/silver/defi/dex/trader_joe/silver_dex__trader_joe_v1_swaps.sql
+++ b/models/silver/defi/dex/trader_joe/silver_dex__trader_joe_v1_swaps.sql
@@ -59,6 +59,7 @@ swaps_base AS (
         ON p.pool_address = l.contract_address
     WHERE
         l.topics [0] :: STRING = '0xd78ad95fa46c994b6551d0da85fc275fe613ce37657fb8d5e3d130840159d822' --Swap
+        AND tx_status = 'SUCCESS'
 
 {% if is_incremental() %}
 AND _inserted_timestamp >= (

--- a/models/silver/defi/dex/trader_joe/silver_dex__trader_joe_v2_1_swaps.sql
+++ b/models/silver/defi/dex/trader_joe/silver_dex__trader_joe_v2_1_swaps.sql
@@ -79,6 +79,7 @@ swaps_base AS (
         ON lb_pair = l.contract_address
     WHERE
         topics [0] :: STRING = '0xad7d6f97abf51ce18e17a38f4d70e975be9c0708474987bb3e26ad21bd93ca70' --Swap
+        AND tx_status = 'SUCCESS'
 
 {% if is_incremental() %}
 AND _inserted_timestamp >= (

--- a/models/silver/defi/dex/trader_joe/silver_dex__trader_joe_v2_pools.sql
+++ b/models/silver/defi/dex/trader_joe/silver_dex__trader_joe_v2_pools.sql
@@ -35,6 +35,7 @@ WITH pool_creation AS (
             '0x8597db3ba8de6baadeda8cba4dac653e24a0e57b'
         )
         AND topics [0] :: STRING = '0x2c8d104b27c6b7f4492017a6f5cf3803043688934ebcaa6a03540beeaf976aff' --LB PairCreated
+        AND tx_status = 'SUCCESS'
 
 {% if is_incremental() %}
 AND _inserted_timestamp >= (

--- a/models/silver/defi/dex/trader_joe/silver_dex__trader_joe_v2_swaps.sql
+++ b/models/silver/defi/dex/trader_joe/silver_dex__trader_joe_v2_swaps.sql
@@ -78,6 +78,7 @@ swaps_base AS (
         ON lb_pair = l.contract_address
     WHERE
         topics [0] :: STRING = '0xc528cda9e500228b16ce84fadae290d9a49aecb17483110004c5af0a07f6fd73' --Swap
+        AND tx_status = 'SUCCESS'
 
 {% if is_incremental() %}
 AND _inserted_timestamp >= (

--- a/models/silver/defi/dex/uniswap/silver_dex__univ2_pools.sql
+++ b/models/silver/defi/dex/uniswap/silver_dex__univ2_pools.sql
@@ -27,6 +27,7 @@ WITH pool_creation AS (
     WHERE
         contract_address = LOWER('0xf1D7CC64Fb4452F05c498126312eBE29f30Fbcf9')
         AND topics [0] :: STRING = '0x0d3648bd0f6ba80134a33ba9275ac585d9d315f0ad8355cddefde31afa28d0e9' --PairCreated
+        AND tx_status = 'SUCCESS'
 
 {% if is_incremental() %}
 AND _inserted_timestamp >= (

--- a/models/silver/defi/dex/uniswap/silver_dex__univ3_pools.sql
+++ b/models/silver/defi/dex/uniswap/silver_dex__univ3_pools.sql
@@ -32,6 +32,7 @@ WITH created_pools AS (
     WHERE
         topics [0] = '0x783cca1c0412dd0d695e784568c96da2e9c22ff989357a2e8b1d9b2b4e6b7118'
         AND contract_address = '0x1f98431c8ad98523631ae4a59f267346ea31f984'
+        AND tx_status = 'SUCCESS'
 
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
@@ -58,6 +59,7 @@ initial_info AS (
         {{ ref('silver__logs') }}
     WHERE
         topics [0] :: STRING = '0x98636036cb66a9c19a37435efc1e90142190214e8abeb821bdba3f2990dd4c95'
+        AND tx_status = 'SUCCESS'
 
 {% if is_incremental() %}
 AND _inserted_timestamp >= (

--- a/models/silver/defi/dex/woofi/silver_dex__woofi_swaps.sql
+++ b/models/silver/defi/dex/woofi/silver_dex__woofi_swaps.sql
@@ -66,6 +66,7 @@ WITH router_swaps_base AS (
             '0xb130a49065178465931d4f887056328cea5d723f'
         ) --v3
         AND topics [0] :: STRING = '0x27c98e911efdd224f4002f6cd831c3ad0d2759ee176f9ee8466d95826af22a1c' --WooRouterSwap
+        AND tx_status = 'SUCCESS'
 
 {% if is_incremental() %}
 AND _inserted_timestamp >= (
@@ -141,6 +142,7 @@ swaps_base AS (
             FROM
                 router_swaps_base
         )
+        AND tx_status = 'SUCCESS'
 
 {% if is_incremental() %}
 AND _inserted_timestamp >= (

--- a/models/silver/defi/dex/zyberswap/silver_dex__zyberswap_pools.sql
+++ b/models/silver/defi/dex/zyberswap/silver_dex__zyberswap_pools.sql
@@ -32,6 +32,7 @@ WITH pool_creation AS (
             --PairCreated v2
             '0x91ccaa7a278130b65168c3a0c8d3bcae84cf5e43704342bd3ec0b59e59c036db'
         ) --v3
+        AND tx_status = 'SUCCESS'
 
 {% if is_incremental() %}
 AND _inserted_timestamp >= (

--- a/models/silver/defi/lending/complete_lending/silver__complete_lending_borrows.sql
+++ b/models/silver/defi/lending/complete_lending/silver__complete_lending_borrows.sql
@@ -37,7 +37,7 @@ WHERE
         SELECT
             MAX(
                 _inserted_timestamp
-            ) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
+            ) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
         FROM
             {{ this }}
     )
@@ -72,7 +72,7 @@ radiant as (
             SELECT
                 MAX(
                     _inserted_timestamp
-                ) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
+                ) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
             FROM
                 {{ this }}
         )
@@ -107,7 +107,7 @@ lodestar as (
             SELECT
                 MAX(
                     _inserted_timestamp
-                ) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
+                ) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
             FROM
                 {{ this }}
         )
@@ -142,7 +142,7 @@ dforce as (
             SELECT
                 MAX(
                     _inserted_timestamp
-                ) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
+                ) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
             FROM
                 {{ this }}
         )
@@ -178,7 +178,7 @@ comp as (
             SELECT
                 MAX(
                     _inserted_timestamp
-                ) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
+                ) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
             FROM
                 {{ this }}
         )
@@ -214,7 +214,7 @@ silo as (
             SELECT
                 MAX(
                     _inserted_timestamp
-                ) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
+                ) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
             FROM
                 {{ this }}
         )

--- a/models/silver/defi/lending/complete_lending/silver__complete_lending_borrows.sql
+++ b/models/silver/defi/lending/complete_lending/silver__complete_lending_borrows.sql
@@ -43,7 +43,7 @@ WHERE
     )
 {% endif %}
 ),
-radiant as (
+radiant AS (
     SELECT
         tx_hash,
         block_number,
@@ -66,19 +66,19 @@ radiant as (
     FROM
         {{ ref('silver__radiant_borrows') }} A
 
-    {% if is_incremental() and 'radiant' not in var('HEAL_MODELS') %}
-    WHERE
-        A._inserted_timestamp >= (
-            SELECT
-                MAX(
-                    _inserted_timestamp
-                ) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
-            FROM
-                {{ this }}
-        )
-    {% endif %}
+{% if is_incremental() and 'radiant' not in var('HEAL_MODELS') %}
+WHERE
+    A._inserted_timestamp >= (
+        SELECT
+            MAX(
+                _inserted_timestamp
+            ) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
+        FROM
+            {{ this }}
+    )
+{% endif %}
 ),
-lodestar as (
+lodestar AS (
     SELECT
         tx_hash,
         block_number,
@@ -101,19 +101,19 @@ lodestar as (
     FROM
         {{ ref('silver__lodestar_borrows') }} A
 
-    {% if is_incremental() and 'lodestar' not in var('HEAL_MODELS') %}
-    WHERE
-        A._inserted_timestamp >= (
-            SELECT
-                MAX(
-                    _inserted_timestamp
-                ) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
-            FROM
-                {{ this }}
-        )
-    {% endif %}
+{% if is_incremental() and 'lodestar' not in var('HEAL_MODELS') %}
+WHERE
+    A._inserted_timestamp >= (
+        SELECT
+            MAX(
+                _inserted_timestamp
+            ) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
+        FROM
+            {{ this }}
+    )
+{% endif %}
 ),
-dforce as (
+dforce AS (
     SELECT
         tx_hash,
         block_number,
@@ -137,18 +137,18 @@ dforce as (
         {{ ref('silver__dforce_borrows') }} A
 
 {% if is_incremental() and 'dforce' not in var('HEAL_MODELS') %}
-    WHERE
-        A._inserted_timestamp >= (
-            SELECT
-                MAX(
-                    _inserted_timestamp
-                ) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
-            FROM
-                {{ this }}
-        )
-    {% endif %}
+WHERE
+    A._inserted_timestamp >= (
+        SELECT
+            MAX(
+                _inserted_timestamp
+            ) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
+        FROM
+            {{ this }}
+    )
+{% endif %}
 ),
-comp as (
+comp AS (
     SELECT
         tx_hash,
         block_number,
@@ -172,19 +172,19 @@ comp as (
         {{ ref('silver__comp_borrows') }}
         l
 
-    {% if is_incremental() and 'comp' not in var('HEAL_MODELS') %}
-    WHERE
-        l._inserted_timestamp >= (
-            SELECT
-                MAX(
-                    _inserted_timestamp
-                ) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
-            FROM
-                {{ this }}
-        )
-    {% endif %}
+{% if is_incremental() and 'comp' not in var('HEAL_MODELS') %}
+WHERE
+    l._inserted_timestamp >= (
+        SELECT
+            MAX(
+                _inserted_timestamp
+            ) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
+        FROM
+            {{ this }}
+    )
+{% endif %}
 ),
-silo as (
+silo AS (
     SELECT
         tx_hash,
         block_number,
@@ -208,50 +208,50 @@ silo as (
         {{ ref('silver__silo_borrows') }}
         l
 
-    {% if is_incremental() and 'silo' not in var('HEAL_MODELS') %}
-    WHERE
-        l._inserted_timestamp >= (
-            SELECT
-                MAX(
-                    _inserted_timestamp
-                ) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
-            FROM
-                {{ this }}
-        )
-    {% endif %}
+{% if is_incremental() and 'silo' not in var('HEAL_MODELS') %}
+WHERE
+    l._inserted_timestamp >= (
+        SELECT
+            MAX(
+                _inserted_timestamp
+            ) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
+        FROM
+            {{ this }}
+    )
+{% endif %}
 ),
-borrow_union as (
-  SELECT
-    *
-  FROM
-    aave
-  UNION ALL
-  SELECT
-    *
-  FROM
-    radiant
-  UNION ALL
-  SELECT
-    *
-  FROM
-    comp
-  UNION ALL
-  SELECT
-    *
-  FROM
-    dforce
-  UNION ALL
-  SELECT
-    *
-  FROM
-    lodestar
-  UNION ALL
-  SELECT
-    *
-  FROM
-    silo
+borrow_union AS (
+    SELECT
+        *
+    FROM
+        aave
+    UNION ALL
+    SELECT
+        *
+    FROM
+        radiant
+    UNION ALL
+    SELECT
+        *
+    FROM
+        comp
+    UNION ALL
+    SELECT
+        *
+    FROM
+        dforce
+    UNION ALL
+    SELECT
+        *
+    FROM
+        lodestar
+    UNION ALL
+    SELECT
+        *
+    FROM
+        silo
 ),
-FINAL AS (
+complete_lending_borrows AS (
     SELECT
         tx_hash,
         block_number,
@@ -288,8 +288,126 @@ FINAL AS (
             'hour',
             block_timestamp
         ) = p.hour
-        LEFT JOIN {{ ref('silver__contracts') }} C
-        ON b.token_address = C.contract_address
+),
+
+{% if is_incremental() and var(
+    'HEAL_MODEL'
+) %}
+heal_model AS (
+    SELECT
+        tx_hash,
+        block_number,
+        block_timestamp,
+        event_index,
+        origin_from_address,
+        origin_to_address,
+        origin_function_signature,
+        t0.contract_address,
+        event_name,
+        borrower,
+        protocol_market,
+        t0.token_address,
+        t0.token_symbol,
+        amount_unadj,
+        amount,
+        ROUND(
+            amount * p.price,
+            2
+        ) AS amount_usd_heal,
+        platform,
+        t0.blockchain,
+        t0._LOG_ID,
+        t0._INSERTED_TIMESTAMP
+    FROM
+        {{ this }}
+        t0
+        LEFT JOIN {{ ref('price__ez_prices_hourly') }}
+        p
+        ON t0.token_address = p.token_address
+        AND DATE_TRUNC(
+            'hour',
+            block_timestamp
+        ) = p.hour
+    WHERE
+        CONCAT(
+            t0.block_number,
+            '-',
+            t0.platform
+        ) IN (
+            SELECT
+                CONCAT(
+                    t1.block_number,
+                    '-',
+                    t1.platform
+                )
+            FROM
+                {{ this }}
+                t1
+            WHERE
+                t1.amount_usd IS NULL
+                AND t1._inserted_timestamp < (
+                    SELECT
+                        MAX(
+                            _inserted_timestamp
+                        ) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
+                    FROM
+                        {{ this }}
+                )
+                AND EXISTS (
+                    SELECT
+                        1
+                    FROM
+                        {{ ref('silver__complete_token_prices') }}
+                        p
+                    WHERE
+                        p._inserted_timestamp > DATEADD('DAY', -14, SYSDATE())
+                        AND p.price IS NOT NULL
+                        AND p.token_address = t1.token_address
+                        AND p.hour = DATE_TRUNC(
+                            'hour',
+                            t1.block_timestamp
+                        )
+                )
+            GROUP BY
+                1
+        )
+),
+{% endif %}
+
+FINAL AS (
+    SELECT
+        *
+    FROM
+        complete_lending_borrows
+
+{% if is_incremental() and var(
+    'HEAL_MODEL'
+) %}
+UNION ALL
+SELECT
+    tx_hash,
+    block_number,
+    block_timestamp,
+    event_index,
+    origin_from_address,
+    origin_to_address,
+    origin_function_signature,
+    contract_address,
+    event_name,
+    borrower,
+    protocol_market,
+    token_address,
+    token_symbol,
+    amount_unadj,
+    amount,
+    amount_usd_heal AS amount_usd,
+    platform,
+    blockchain,
+    _LOG_ID,
+    _INSERTED_TIMESTAMP
+FROM
+    heal_model
+{% endif %}
 )
 SELECT
     *,

--- a/models/silver/defi/lending/complete_lending/silver__complete_lending_borrows.sql
+++ b/models/silver/defi/lending/complete_lending/silver__complete_lending_borrows.sql
@@ -1,9 +1,10 @@
+-- depends_on: {{ ref('silver__complete_token_prices') }}
 {{ config(
     materialized = 'incremental',
     incremental_strategy = 'delete+insert',
     unique_key = ['block_number','platform'],
     cluster_by = ['block_timestamp::DATE'],
-    tags = ['reorg','curated']
+    tags = ['reorg','curated','heal']
 ) }}
 
 WITH aave AS (
@@ -30,13 +31,13 @@ WITH aave AS (
     FROM
         {{ ref('silver__aave_borrows') }} A
 
-{% if is_incremental() and 'aave' not in var('HEAL_CURATED_MODEL') %}
+{% if is_incremental() and 'aave' not in var('HEAL_MODELS') %}
 WHERE
     A._inserted_timestamp >= (
         SELECT
             MAX(
                 _inserted_timestamp
-            ) - INTERVAL '36 hours'
+            ) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
         FROM
             {{ this }}
     )
@@ -65,13 +66,13 @@ radiant as (
     FROM
         {{ ref('silver__radiant_borrows') }} A
 
-    {% if is_incremental() and 'radiant' not in var('HEAL_CURATED_MODEL') %}
+    {% if is_incremental() and 'radiant' not in var('HEAL_MODELS') %}
     WHERE
         A._inserted_timestamp >= (
             SELECT
                 MAX(
                     _inserted_timestamp
-                ) - INTERVAL '36 hours'
+                ) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
             FROM
                 {{ this }}
         )
@@ -100,13 +101,13 @@ lodestar as (
     FROM
         {{ ref('silver__lodestar_borrows') }} A
 
-    {% if is_incremental() and 'lodestar' not in var('HEAL_CURATED_MODEL') %}
+    {% if is_incremental() and 'lodestar' not in var('HEAL_MODELS') %}
     WHERE
         A._inserted_timestamp >= (
             SELECT
                 MAX(
                     _inserted_timestamp
-                ) - INTERVAL '36 hours'
+                ) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
             FROM
                 {{ this }}
         )
@@ -135,13 +136,13 @@ dforce as (
     FROM
         {{ ref('silver__dforce_borrows') }} A
 
-{% if is_incremental() and 'dforce' not in var('HEAL_CURATED_MODEL') %}
+{% if is_incremental() and 'dforce' not in var('HEAL_MODELS') %}
     WHERE
         A._inserted_timestamp >= (
             SELECT
                 MAX(
                     _inserted_timestamp
-                ) - INTERVAL '36 hours'
+                ) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
             FROM
                 {{ this }}
         )
@@ -171,13 +172,13 @@ comp as (
         {{ ref('silver__comp_borrows') }}
         l
 
-    {% if is_incremental() and 'comp' not in var('HEAL_CURATED_MODEL') %}
+    {% if is_incremental() and 'comp' not in var('HEAL_MODELS') %}
     WHERE
         l._inserted_timestamp >= (
             SELECT
                 MAX(
                     _inserted_timestamp
-                ) - INTERVAL '36 hours'
+                ) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
             FROM
                 {{ this }}
         )
@@ -207,13 +208,13 @@ silo as (
         {{ ref('silver__silo_borrows') }}
         l
 
-    {% if is_incremental() and 'silo' not in var('HEAL_CURATED_MODEL') %}
+    {% if is_incremental() and 'silo' not in var('HEAL_MODELS') %}
     WHERE
         l._inserted_timestamp >= (
             SELECT
                 MAX(
                     _inserted_timestamp
-                ) - INTERVAL '36 hours'
+                ) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
             FROM
                 {{ this }}
         )

--- a/models/silver/defi/lending/complete_lending/silver__complete_lending_deposits.sql
+++ b/models/silver/defi/lending/complete_lending/silver__complete_lending_deposits.sql
@@ -35,7 +35,7 @@ WITH aave AS (
   WHERE
     _inserted_timestamp >= (
       SELECT
-        MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
+        MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
       FROM
         {{ this }}
     )
@@ -68,7 +68,7 @@ radiant as (
   WHERE
     _inserted_timestamp >= (
       SELECT
-        MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
+        MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
       FROM
         {{ this }}
     )
@@ -101,7 +101,7 @@ comp as (
   WHERE
     _inserted_timestamp >= (
       SELECT
-        MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
+        MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
       FROM
         {{ this }}
     )
@@ -134,7 +134,7 @@ lodestar as (
   WHERE
     _inserted_timestamp >= (
       SELECT
-        MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
+        MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
       FROM
         {{ this }}
     )
@@ -167,7 +167,7 @@ dforce as (
   WHERE
     _inserted_timestamp >= (
       SELECT
-        MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
+        MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
       FROM
         {{ this }}
     )
@@ -200,7 +200,7 @@ silo as (
   WHERE
     _inserted_timestamp >= (
       SELECT
-        MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
+        MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
       FROM
         {{ this }}
     )

--- a/models/silver/defi/lending/complete_lending/silver__complete_lending_deposits.sql
+++ b/models/silver/defi/lending/complete_lending/silver__complete_lending_deposits.sql
@@ -1,9 +1,10 @@
+-- depends_on: {{ ref('silver__complete_token_prices') }}
 {{ config(
-  materialized = 'incremental',
-  incremental_strategy = 'delete+insert',
-  unique_key = ['block_number','platform'],
-  cluster_by = ['block_timestamp::DATE'],
-  tags = ['reorg','curated']
+    materialized = 'incremental',
+    incremental_strategy = 'delete+insert',
+    unique_key = ['block_number','platform'],
+    cluster_by = ['block_timestamp::DATE'],
+    tags = ['reorg','curated','heal']
 ) }}
 
 WITH aave AS (
@@ -30,11 +31,11 @@ WITH aave AS (
     FROM
       {{ ref('silver__aave_deposits') }}
 
-  {% if is_incremental() and 'aave' not in var('HEAL_CURATED_MODEL') %}
+  {% if is_incremental() and 'aave' not in var('HEAL_MODELS') %}
   WHERE
     _inserted_timestamp >= (
       SELECT
-        MAX(_inserted_timestamp) - INTERVAL '36 hours'
+        MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
       FROM
         {{ this }}
     )
@@ -63,11 +64,11 @@ radiant as (
   FROM
     {{ ref('silver__radiant_deposits') }}
 
-  {% if is_incremental() and 'radiant' not in var('HEAL_CURATED_MODEL') %}
+  {% if is_incremental() and 'radiant' not in var('HEAL_MODELS') %}
   WHERE
     _inserted_timestamp >= (
       SELECT
-        MAX(_inserted_timestamp) - INTERVAL '36 hours'
+        MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
       FROM
         {{ this }}
     )
@@ -96,11 +97,11 @@ comp as (
   FROM
     {{ ref('silver__comp_deposits') }}
 
-  {% if is_incremental() and 'comp' not in var('HEAL_CURATED_MODEL') %}
+  {% if is_incremental() and 'comp' not in var('HEAL_MODELS') %}
   WHERE
     _inserted_timestamp >= (
       SELECT
-        MAX(_inserted_timestamp) - INTERVAL '36 hours'
+        MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
       FROM
         {{ this }}
     )
@@ -129,11 +130,11 @@ lodestar as (
   FROM
     {{ ref('silver__lodestar_deposits') }}
 
-  {% if is_incremental() and 'lodestar' not in var('HEAL_CURATED_MODEL') %}
+  {% if is_incremental() and 'lodestar' not in var('HEAL_MODELS') %}
   WHERE
     _inserted_timestamp >= (
       SELECT
-        MAX(_inserted_timestamp) - INTERVAL '36 hours'
+        MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
       FROM
         {{ this }}
     )
@@ -162,11 +163,11 @@ dforce as (
   FROM
     {{ ref('silver__dforce_deposits') }}
 
-  {% if is_incremental() and 'dforce' not in var('HEAL_CURATED_MODEL') %}
+  {% if is_incremental() and 'dforce' not in var('HEAL_MODELS') %}
   WHERE
     _inserted_timestamp >= (
       SELECT
-        MAX(_inserted_timestamp) - INTERVAL '36 hours'
+        MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
       FROM
         {{ this }}
     )
@@ -195,11 +196,11 @@ silo as (
   FROM
     {{ ref('silver__silo_deposits') }}
 
-  {% if is_incremental() and 'aave' not in var('HEAL_CURATED_MODEL') %}
+  {% if is_incremental() and 'aave' not in var('HEAL_MODELS') %}
   WHERE
     _inserted_timestamp >= (
       SELECT
-        MAX(_inserted_timestamp) - INTERVAL '36 hours'
+        MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
       FROM
         {{ this }}
     )

--- a/models/silver/defi/lending/complete_lending/silver__complete_lending_deposits.sql
+++ b/models/silver/defi/lending/complete_lending/silver__complete_lending_deposits.sql
@@ -1,47 +1,47 @@
 -- depends_on: {{ ref('silver__complete_token_prices') }}
 {{ config(
-    materialized = 'incremental',
-    incremental_strategy = 'delete+insert',
-    unique_key = ['block_number','platform'],
-    cluster_by = ['block_timestamp::DATE'],
-    tags = ['reorg','curated','heal']
+  materialized = 'incremental',
+  incremental_strategy = 'delete+insert',
+  unique_key = ['block_number','platform'],
+  cluster_by = ['block_timestamp::DATE'],
+  tags = ['reorg','curated','heal']
 ) }}
 
 WITH aave AS (
 
-    SELECT
-      tx_hash,
-      block_number,
-      block_timestamp,
-      event_index,
-      origin_from_address,
-      origin_to_address,
-      origin_function_signature,
-      contract_address,
-      depositor_address,
-      aave_token AS protocol_market,
-      aave_market AS token_address,
-      symbol AS token_symbol,
-      amount_unadj,
-      amount,
-      platform,
-      'arbitrum' AS blockchain,
-      _LOG_ID,
-      _INSERTED_TIMESTAMP
-    FROM
-      {{ ref('silver__aave_deposits') }}
+  SELECT
+    tx_hash,
+    block_number,
+    block_timestamp,
+    event_index,
+    origin_from_address,
+    origin_to_address,
+    origin_function_signature,
+    contract_address,
+    depositor_address,
+    aave_token AS protocol_market,
+    aave_market AS token_address,
+    symbol AS token_symbol,
+    amount_unadj,
+    amount,
+    platform,
+    'arbitrum' AS blockchain,
+    _LOG_ID,
+    _INSERTED_TIMESTAMP
+  FROM
+    {{ ref('silver__aave_deposits') }}
 
-  {% if is_incremental() and 'aave' not in var('HEAL_MODELS') %}
-  WHERE
-    _inserted_timestamp >= (
-      SELECT
-        MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
-      FROM
-        {{ this }}
-    )
-  {% endif %}
+{% if is_incremental() and 'aave' not in var('HEAL_MODELS') %}
+WHERE
+  _inserted_timestamp >= (
+    SELECT
+      MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
+    FROM
+      {{ this }}
+  )
+{% endif %}
 ),
-radiant as (
+radiant AS (
   SELECT
     tx_hash,
     block_number,
@@ -64,17 +64,17 @@ radiant as (
   FROM
     {{ ref('silver__radiant_deposits') }}
 
-  {% if is_incremental() and 'radiant' not in var('HEAL_MODELS') %}
-  WHERE
-    _inserted_timestamp >= (
-      SELECT
-        MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
-      FROM
-        {{ this }}
-    )
-  {% endif %}
+{% if is_incremental() and 'radiant' not in var('HEAL_MODELS') %}
+WHERE
+  _inserted_timestamp >= (
+    SELECT
+      MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
+    FROM
+      {{ this }}
+  )
+{% endif %}
 ),
-comp as (
+comp AS (
   SELECT
     tx_hash,
     block_number,
@@ -97,17 +97,17 @@ comp as (
   FROM
     {{ ref('silver__comp_deposits') }}
 
-  {% if is_incremental() and 'comp' not in var('HEAL_MODELS') %}
-  WHERE
-    _inserted_timestamp >= (
-      SELECT
-        MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
-      FROM
-        {{ this }}
-    )
-  {% endif %}
+{% if is_incremental() and 'comp' not in var('HEAL_MODELS') %}
+WHERE
+  _inserted_timestamp >= (
+    SELECT
+      MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
+    FROM
+      {{ this }}
+  )
+{% endif %}
 ),
-lodestar as (
+lodestar AS (
   SELECT
     tx_hash,
     block_number,
@@ -130,17 +130,17 @@ lodestar as (
   FROM
     {{ ref('silver__lodestar_deposits') }}
 
-  {% if is_incremental() and 'lodestar' not in var('HEAL_MODELS') %}
-  WHERE
-    _inserted_timestamp >= (
-      SELECT
-        MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
-      FROM
-        {{ this }}
-    )
-  {% endif %}
+{% if is_incremental() and 'lodestar' not in var('HEAL_MODELS') %}
+WHERE
+  _inserted_timestamp >= (
+    SELECT
+      MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
+    FROM
+      {{ this }}
+  )
+{% endif %}
 ),
-dforce as (
+dforce AS (
   SELECT
     tx_hash,
     block_number,
@@ -163,17 +163,17 @@ dforce as (
   FROM
     {{ ref('silver__dforce_deposits') }}
 
-  {% if is_incremental() and 'dforce' not in var('HEAL_MODELS') %}
-  WHERE
-    _inserted_timestamp >= (
-      SELECT
-        MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
-      FROM
-        {{ this }}
-    )
-  {% endif %}
+{% if is_incremental() and 'dforce' not in var('HEAL_MODELS') %}
+WHERE
+  _inserted_timestamp >= (
+    SELECT
+      MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
+    FROM
+      {{ this }}
+  )
+{% endif %}
 ),
-silo as (
+silo AS (
   SELECT
     tx_hash,
     block_number,
@@ -196,17 +196,17 @@ silo as (
   FROM
     {{ ref('silver__silo_deposits') }}
 
-  {% if is_incremental() and 'aave' not in var('HEAL_MODELS') %}
-  WHERE
-    _inserted_timestamp >= (
-      SELECT
-        MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
-      FROM
-        {{ this }}
-    )
-  {% endif %}
+{% if is_incremental() and 'aave' not in var('HEAL_MODELS') %}
+WHERE
+  _inserted_timestamp >= (
+    SELECT
+      MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
+    FROM
+      {{ this }}
+  )
+{% endif %}
 ),
-deposits as (
+deposits AS (
   SELECT
     *
   FROM
@@ -237,7 +237,7 @@ deposits as (
   FROM
     silo
 ),
-FINAL AS (
+complete_lending_deposits AS (
   SELECT
     tx_hash,
     block_number,
@@ -276,17 +276,135 @@ FINAL AS (
       'hour',
       block_timestamp
     ) = p.hour
-    LEFT JOIN {{ ref('silver__contracts') }} C
-    ON A.token_address = C.contract_address
+),
+
+{% if is_incremental() and var(
+  'HEAL_MODEL'
+) %}
+heal_model AS (
+  SELECT
+    tx_hash,
+    block_number,
+    block_timestamp,
+    event_index,
+    origin_from_address,
+    origin_to_address,
+    origin_function_signature,
+    t0.contract_address,
+    event_name,
+    protocol_market,
+    depositor,
+    t0.token_address,
+    t0.token_symbol,
+    amount_unadj,
+    amount,
+    ROUND(
+      amount * p.price,
+      2
+    ) AS amount_usd_heal,
+    platform,
+    t0.blockchain,
+    t0._LOG_ID,
+    t0._INSERTED_TIMESTAMP
+  FROM
+    {{ this }}
+    t0
+    LEFT JOIN {{ ref('price__ez_prices_hourly') }}
+    p
+    ON t0.token_address = p.token_address
+    AND DATE_TRUNC(
+      'hour',
+      block_timestamp
+    ) = p.hour
+  WHERE
+    CONCAT(
+      t0.block_number,
+      '-',
+      t0.platform
+    ) IN (
+      SELECT
+        CONCAT(
+          t1.block_number,
+          '-',
+          t1.platform
+        )
+      FROM
+        {{ this }}
+        t1
+      WHERE
+        t1.amount_usd IS NULL
+        AND t1._inserted_timestamp < (
+          SELECT
+            MAX(
+              _inserted_timestamp
+            ) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
+          FROM
+            {{ this }}
+        )
+        AND EXISTS (
+          SELECT
+            1
+          FROM
+            {{ ref('silver__complete_token_prices') }}
+            p
+          WHERE
+            p._inserted_timestamp > DATEADD('DAY', -14, SYSDATE())
+            AND p.price IS NOT NULL
+            AND p.token_address = t1.token_address
+            AND p.hour = DATE_TRUNC(
+              'hour',
+              t1.block_timestamp
+            )
+        )
+      GROUP BY
+        1
+    )
+),
+{% endif %}
+
+FINAL AS (
+  SELECT
+    *
+  FROM
+    complete_lending_deposits
+
+{% if is_incremental() and var(
+  'HEAL_MODEL'
+) %}
+UNION ALL
+SELECT
+  tx_hash,
+  block_number,
+  block_timestamp,
+  event_index,
+  origin_from_address,
+  origin_to_address,
+  origin_function_signature,
+  contract_address,
+  event_name,
+  protocol_market,
+  depositor,
+  token_address,
+  token_symbol,
+  amount_unadj,
+  amount,
+  amount_usd_heal AS amount_usd,
+  platform,
+  blockchain,
+  _LOG_ID,
+  _INSERTED_TIMESTAMP
+FROM
+  heal_model
+{% endif %}
 )
 SELECT
-      *,
-    {{ dbt_utils.generate_surrogate_key(
-        ['tx_hash','event_index']
-    ) }} AS complete_lending_deposits_id,
-    SYSDATE() AS inserted_timestamp,
-    SYSDATE() AS modified_timestamp,
-    '{{ invocation_id }}' AS _invocation_id
+  *,
+  {{ dbt_utils.generate_surrogate_key(
+    ['tx_hash','event_index']
+  ) }} AS complete_lending_deposits_id,
+  SYSDATE() AS inserted_timestamp,
+  SYSDATE() AS modified_timestamp,
+  '{{ invocation_id }}' AS _invocation_id
 FROM
   FINAL qualify(ROW_NUMBER() over(PARTITION BY _log_id
 ORDER BY

--- a/models/silver/defi/lending/complete_lending/silver__complete_lending_flashloans.sql
+++ b/models/silver/defi/lending/complete_lending/silver__complete_lending_flashloans.sql
@@ -63,7 +63,7 @@ radiant AS (
     initiator_address,
     target_address,
     platform,
-    symbol AS token_symbol,
+    symbol,
     blockchain,
     _LOG_ID,
     _INSERTED_TIMESTAMP
@@ -106,7 +106,7 @@ complete_lending_flashloans AS (
     initiator_address AS initiator,
     target_address AS target,
     f.token_address AS flashloan_token,
-    token_symbol AS flashloan_token_symbol,
+    f.symbol AS flashloan_token_symbol,
     flashloan_amount_unadj,
     flashloan_amount,
     ROUND(

--- a/models/silver/defi/lending/complete_lending/silver__complete_lending_flashloans.sql
+++ b/models/silver/defi/lending/complete_lending/silver__complete_lending_flashloans.sql
@@ -38,7 +38,7 @@ WITH aave AS (
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
+      MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
     FROM
       {{ this }}
   )
@@ -74,7 +74,7 @@ radiant as (
   WHERE
     _inserted_timestamp >= (
       SELECT
-        MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
+        MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
       FROM
         {{ this }}
     )

--- a/models/silver/defi/lending/complete_lending/silver__complete_lending_flashloans.sql
+++ b/models/silver/defi/lending/complete_lending/silver__complete_lending_flashloans.sql
@@ -1,10 +1,10 @@
 -- depends_on: {{ ref('silver__complete_token_prices') }}
 {{ config(
-    materialized = 'incremental',
-    incremental_strategy = 'delete+insert',
-    unique_key = ['block_number','platform'],
-    cluster_by = ['block_timestamp::DATE'],
-    tags = ['reorg','curated','heal']
+  materialized = 'incremental',
+  incremental_strategy = 'delete+insert',
+  unique_key = ['block_number','platform'],
+  cluster_by = ['block_timestamp::DATE'],
+  tags = ['reorg','curated','heal']
 ) }}
 
 WITH aave AS (
@@ -44,7 +44,7 @@ WHERE
   )
 {% endif %}
 ),
-radiant as (
+radiant AS (
   SELECT
     tx_hash,
     block_number,
@@ -70,17 +70,17 @@ radiant as (
   FROM
     {{ ref('silver__radiant_flashloans') }}
 
-  {% if is_incremental() and 'radiant' not in var('HEAL_MODELS') %}
-  WHERE
-    _inserted_timestamp >= (
-      SELECT
-        MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
-      FROM
-        {{ this }}
-    )
-  {% endif %}
+{% if is_incremental() and 'radiant' not in var('HEAL_MODELS') %}
+WHERE
+  _inserted_timestamp >= (
+    SELECT
+      MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
+    FROM
+      {{ this }}
+  )
+{% endif %}
 ),
-flashloans as (
+flashloans AS (
   SELECT
     *
   FROM
@@ -91,7 +91,7 @@ flashloans as (
   FROM
     radiant
 ),
-FINAL AS (
+complete_lending_flashloans AS (
   SELECT
     tx_hash,
     block_number,
@@ -132,8 +132,179 @@ FINAL AS (
       'hour',
       block_timestamp
     ) = p.hour
-    LEFT JOIN {{ ref('silver__contracts') }} C
-    ON f.token_address = C.contract_address
+),
+
+{% if is_incremental() and var(
+  'HEAL_MODEL'
+) %}
+heal_model AS (
+  SELECT
+    tx_hash,
+    block_number,
+    block_timestamp,
+    event_index,
+    origin_from_address,
+    origin_to_address,
+    origin_function_signature,
+    t0.contract_address,
+    event_name,
+    protocol_market,
+    initiator,
+    target,
+    flashloan_token,
+    flashloan_token_symbol,
+    flashloan_amount_unadj,
+    flashloan_amount,
+    ROUND(
+      flashloan_amount * p.price,
+      2
+    ) AS flashloan_amount_usd_heal,
+    premium_amount_unadj,
+    premium_amount,
+    ROUND(
+      premium_amount * p.price,
+      2
+    ) AS premium_amount_usd_heal,
+    platform,
+    t0.blockchain,
+    t0._LOG_ID,
+    t0._INSERTED_TIMESTAMP
+  FROM
+    {{ this }}
+    t0
+    LEFT JOIN {{ ref('price__ez_prices_hourly') }}
+    p
+    ON t0.flashloan_token = p.token_address
+    AND DATE_TRUNC(
+      'hour',
+      block_timestamp
+    ) = p.hour
+  WHERE
+    CONCAT(
+      t0.block_number,
+      '-',
+      t0.platform
+    ) IN (
+      SELECT
+        CONCAT(
+          t1.block_number,
+          '-',
+          t1.platform
+        )
+      FROM
+        {{ this }}
+        t1
+      WHERE
+        t1.flashloan_amount_usd IS NULL
+        AND t1._inserted_timestamp < (
+          SELECT
+            MAX(
+              _inserted_timestamp
+            ) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
+          FROM
+            {{ this }}
+        )
+        AND EXISTS (
+          SELECT
+            1
+          FROM
+            {{ ref('silver__complete_token_prices') }}
+            p
+          WHERE
+            p._inserted_timestamp > DATEADD('DAY', -14, SYSDATE())
+            AND p.price IS NOT NULL
+            AND p.token_address = t1.flashloan_token
+            AND p.hour = DATE_TRUNC(
+              'hour',
+              t1.block_timestamp
+            )
+        )
+      GROUP BY
+        1
+    )
+    OR CONCAT(
+      t0.block_number,
+      '-',
+      t0.platform
+    ) IN (
+      SELECT
+        CONCAT(
+          t2.block_number,
+          '-',
+          t2.platform
+        )
+      FROM
+        {{ this }}
+        t2
+      WHERE
+        t2.premium_amount_usd IS NULL
+        AND t2._inserted_timestamp < (
+          SELECT
+            MAX(
+              _inserted_timestamp
+            ) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
+          FROM
+            {{ this }}
+        )
+        AND EXISTS (
+          SELECT
+            1
+          FROM
+            {{ ref('silver__complete_token_prices') }}
+            p
+          WHERE
+            p._inserted_timestamp > DATEADD('DAY', -14, SYSDATE())
+            AND p.price IS NOT NULL
+            AND p.token_address = t2.flashloan_token
+            AND p.hour = DATE_TRUNC(
+              'hour',
+              t2.block_timestamp
+            )
+        )
+      GROUP BY
+        1
+    )
+),
+{% endif %}
+
+FINAL AS (
+  SELECT
+    *
+  FROM
+    complete_lending_flashloans
+
+{% if is_incremental() and var(
+  'HEAL_MODEL'
+) %}
+UNION ALL
+SELECT
+  tx_hash,
+  block_number,
+  block_timestamp,
+  event_index,
+  origin_from_address,
+  origin_to_address,
+  origin_function_signature,
+  contract_address,
+  event_name,
+  protocol_market,
+  initiator,
+  target,
+  flashloan_token,
+  flashloan_token_symbol,
+  flashloan_amount_unadj,
+  flashloan_amount,
+  flashloan_amount_usd_heal AS flashloan_amount_usd,
+  premium_amount_unadj,
+  premium_amount,
+  premium_amount_usd_heal AS premium_amount_usd,
+  platform,
+  blockchain,
+  _LOG_ID,
+  _INSERTED_TIMESTAMP
+FROM
+  heal_model
+{% endif %}
 )
 SELECT
   *,

--- a/models/silver/defi/lending/complete_lending/silver__complete_lending_flashloans.sql
+++ b/models/silver/defi/lending/complete_lending/silver__complete_lending_flashloans.sql
@@ -1,9 +1,10 @@
+-- depends_on: {{ ref('silver__complete_token_prices') }}
 {{ config(
-  materialized = 'incremental',
-  incremental_strategy = 'delete+insert',
-  unique_key = ['block_number','platform'],
-  cluster_by = ['block_timestamp::DATE'],
-  tags = ['reorg','curated']
+    materialized = 'incremental',
+    incremental_strategy = 'delete+insert',
+    unique_key = ['block_number','platform'],
+    cluster_by = ['block_timestamp::DATE'],
+    tags = ['reorg','curated','heal']
 ) }}
 
 WITH aave AS (
@@ -33,11 +34,11 @@ WITH aave AS (
   FROM
     {{ ref('silver__aave_flashloans') }}
 
-{% if is_incremental() and 'aave' not in var('HEAL_CURATED_MODEL') %}
+{% if is_incremental() and 'aave' not in var('HEAL_MODELS') %}
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) - INTERVAL '36 hours'
+      MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
     FROM
       {{ this }}
   )
@@ -69,11 +70,11 @@ radiant as (
   FROM
     {{ ref('silver__radiant_flashloans') }}
 
-  {% if is_incremental() and 'radiant' not in var('HEAL_CURATED_MODEL') %}
+  {% if is_incremental() and 'radiant' not in var('HEAL_MODELS') %}
   WHERE
     _inserted_timestamp >= (
       SELECT
-        MAX(_inserted_timestamp) - INTERVAL '36 hours'
+        MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
       FROM
         {{ this }}
     )

--- a/models/silver/defi/lending/complete_lending/silver__complete_lending_liquidations.sql
+++ b/models/silver/defi/lending/complete_lending/silver__complete_lending_liquidations.sql
@@ -1,9 +1,10 @@
+-- depends_on: {{ ref('silver__complete_token_prices') }}
 {{ config(
-  materialized = 'incremental',
-  incremental_strategy = 'delete+insert',
-  unique_key = ['block_number','platform'],
-  cluster_by = ['block_timestamp::DATE'],
-  tags = ['reorg','curated']
+    materialized = 'incremental',
+    incremental_strategy = 'delete+insert',
+    unique_key = ['block_number','platform'],
+    cluster_by = ['block_timestamp::DATE'],
+    tags = ['reorg','curated','heal']
 ) }}
 
 WITH Lodestar AS (
@@ -35,11 +36,11 @@ WITH Lodestar AS (
       {{ ref('silver__lodestar_liquidations') }}
       l
 
-{% if is_incremental() and 'lodestar' not in var('HEAL_CURATED_MODEL') %}
+{% if is_incremental() and 'lodestar' not in var('HEAL_MODELS') %}
 WHERE
   l._inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) - INTERVAL '36 hours'
+      MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
     FROM
       {{ this }}
   )
@@ -73,11 +74,11 @@ dforce as (
       {{ ref('silver__dforce_liquidations') }}
       l
 
-  {% if is_incremental() and 'dforce' not in var('HEAL_CURATED_MODEL') %}
+  {% if is_incremental() and 'dforce' not in var('HEAL_MODELS') %}
   WHERE
     l._inserted_timestamp >= (
       SELECT
-        MAX(_inserted_timestamp) - INTERVAL '36 hours'
+        MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
       FROM
         {{ this }}
     )
@@ -110,11 +111,11 @@ aave as (
   FROM
     {{ ref('silver__aave_liquidations') }}
 
-  {% if is_incremental() and 'aave' not in var('HEAL_CURATED_MODEL') %}
+  {% if is_incremental() and 'aave' not in var('HEAL_MODELS') %}
   WHERE
     _inserted_timestamp >= (
       SELECT
-        MAX(_inserted_timestamp) - INTERVAL '12 hours'
+        MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
       FROM
         {{ this }}
     )
@@ -147,11 +148,11 @@ radiant as (
   FROM
     {{ ref('silver__radiant_liquidations') }}
 
-  {% if is_incremental() and 'radiant' not in var('HEAL_CURATED_MODEL') %}
+  {% if is_incremental() and 'radiant' not in var('HEAL_MODELS') %}
   WHERE
     _inserted_timestamp >= (
       SELECT
-        MAX(_inserted_timestamp) - INTERVAL '36 hours'
+        MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
       FROM
         {{ this }}
     )
@@ -185,11 +186,11 @@ silo as (
   FROM
     {{ ref('silver__silo_liquidations') }}
 
-  {% if is_incremental() and 'silo' not in var('HEAL_CURATED_MODEL') %}
+  {% if is_incremental() and 'silo' not in var('HEAL_MODELS') %}
   WHERE
     _inserted_timestamp >= (
       SELECT
-        MAX(_inserted_timestamp) - INTERVAL '36 hours'
+        MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
       FROM
         {{ this }}
     )
@@ -224,11 +225,11 @@ comp as (
     {{ ref('silver__comp_liquidations') }}
     l
 
-  {% if is_incremental() and 'comp' not in var('HEAL_CURATED_MODEL') %}
+  {% if is_incremental() and 'comp' not in var('HEAL_MODELS') %}
   WHERE
     l._inserted_timestamp >= (
       SELECT
-        MAX(_inserted_timestamp) - INTERVAL '36 hours'
+        MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
       FROM
         {{ this }}
     )

--- a/models/silver/defi/lending/complete_lending/silver__complete_lending_liquidations.sql
+++ b/models/silver/defi/lending/complete_lending/silver__complete_lending_liquidations.sql
@@ -1,40 +1,40 @@
 -- depends_on: {{ ref('silver__complete_token_prices') }}
 {{ config(
-    materialized = 'incremental',
-    incremental_strategy = 'delete+insert',
-    unique_key = ['block_number','platform'],
-    cluster_by = ['block_timestamp::DATE'],
-    tags = ['reorg','curated','heal']
+  materialized = 'incremental',
+  incremental_strategy = 'delete+insert',
+  unique_key = ['block_number','platform'],
+  cluster_by = ['block_timestamp::DATE'],
+  tags = ['reorg','curated','heal']
 ) }}
 
-WITH Lodestar AS (
+WITH lodestar AS (
 
-    SELECT
-      tx_hash,
-      block_number,
-      block_timestamp,
-      event_index,
-      origin_from_address,
-      origin_to_address,
-      origin_function_signature,
-      contract_address,
-      liquidator,
-      borrower,
-      amount_unadj,
-      liquidation_amount AS liquidated_amount,
-      NULL AS liquidated_amount_usd,
-      itoken AS protocol_collateral_asset,
-      liquidation_contract_address AS debt_asset,
-      liquidation_contract_symbol AS debt_asset_symbol,
-      collateral_token AS collateral_asset,
-      collateral_symbol AS collateral_asset_symbol,
-      platform,
-      'arbitrum' AS blockchain,
-      l._LOG_ID,
-      l._INSERTED_TIMESTAMP
-    FROM
-      {{ ref('silver__lodestar_liquidations') }}
-      l
+  SELECT
+    tx_hash,
+    block_number,
+    block_timestamp,
+    event_index,
+    origin_from_address,
+    origin_to_address,
+    origin_function_signature,
+    contract_address,
+    liquidator,
+    borrower,
+    amount_unadj,
+    liquidation_amount AS liquidated_amount,
+    NULL AS liquidated_amount_usd,
+    itoken AS protocol_collateral_asset,
+    liquidation_contract_address AS debt_asset,
+    liquidation_contract_symbol AS debt_asset_symbol,
+    collateral_token AS collateral_asset,
+    collateral_symbol AS collateral_asset_symbol,
+    platform,
+    'arbitrum' AS blockchain,
+    l._LOG_ID,
+    l._INSERTED_TIMESTAMP
+  FROM
+    {{ ref('silver__lodestar_liquidations') }}
+    l
 
 {% if is_incremental() and 'lodestar' not in var('HEAL_MODELS') %}
 WHERE
@@ -46,45 +46,45 @@ WHERE
   )
 {% endif %}
 ),
-dforce as (
-    SELECT
-      tx_hash,
-      block_number,
-      block_timestamp,
-      event_index,
-      origin_from_address,
-      origin_to_address,
-      origin_function_signature,
-      contract_address,
-      liquidator,
-      borrower,
-      amount_unadj,
-      amount AS liquidated_amount,
-      NULL AS liquidated_amount_usd,
-      token AS protocol_collateral_asset,
-      liquidation_contract_address AS debt_asset,
-      liquidation_contract_symbol AS debt_asset_symbol,
-      collateral_token AS collateral_asset,
-      collateral_symbol AS collateral_asset_symbol,
-      platform,
-      'arbitrum' AS blockchain,
-      l._LOG_ID,
-      l._INSERTED_TIMESTAMP
-    FROM
-      {{ ref('silver__dforce_liquidations') }}
-      l
+dforce AS (
+  SELECT
+    tx_hash,
+    block_number,
+    block_timestamp,
+    event_index,
+    origin_from_address,
+    origin_to_address,
+    origin_function_signature,
+    contract_address,
+    liquidator,
+    borrower,
+    amount_unadj,
+    amount AS liquidated_amount,
+    NULL AS liquidated_amount_usd,
+    token AS protocol_collateral_asset,
+    liquidation_contract_address AS debt_asset,
+    liquidation_contract_symbol AS debt_asset_symbol,
+    collateral_token AS collateral_asset,
+    collateral_symbol AS collateral_asset_symbol,
+    platform,
+    'arbitrum' AS blockchain,
+    l._LOG_ID,
+    l._INSERTED_TIMESTAMP
+  FROM
+    {{ ref('silver__dforce_liquidations') }}
+    l
 
-  {% if is_incremental() and 'dforce' not in var('HEAL_MODELS') %}
-  WHERE
-    l._inserted_timestamp >= (
-      SELECT
-        MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
-      FROM
-        {{ this }}
-    )
-  {% endif %}
+{% if is_incremental() and 'dforce' not in var('HEAL_MODELS') %}
+WHERE
+  l._inserted_timestamp >= (
+    SELECT
+      MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
+    FROM
+      {{ this }}
+  )
+{% endif %}
 ),
-aave as (
+aave AS (
   SELECT
     tx_hash,
     block_number,
@@ -111,17 +111,17 @@ aave as (
   FROM
     {{ ref('silver__aave_liquidations') }}
 
-  {% if is_incremental() and 'aave' not in var('HEAL_MODELS') %}
-  WHERE
-    _inserted_timestamp >= (
-      SELECT
-        MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
-      FROM
-        {{ this }}
-    )
-  {% endif %}
+{% if is_incremental() and 'aave' not in var('HEAL_MODELS') %}
+WHERE
+  _inserted_timestamp >= (
+    SELECT
+      MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
+    FROM
+      {{ this }}
+  )
+{% endif %}
 ),
-radiant as (
+radiant AS (
   SELECT
     tx_hash,
     block_number,
@@ -148,18 +148,17 @@ radiant as (
   FROM
     {{ ref('silver__radiant_liquidations') }}
 
-  {% if is_incremental() and 'radiant' not in var('HEAL_MODELS') %}
-  WHERE
-    _inserted_timestamp >= (
-      SELECT
-        MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
-      FROM
-        {{ this }}
-    )
-  {% endif %}
+{% if is_incremental() and 'radiant' not in var('HEAL_MODELS') %}
+WHERE
+  _inserted_timestamp >= (
+    SELECT
+      MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
+    FROM
+      {{ this }}
+  )
+{% endif %}
 ),
-
-silo as (
+silo AS (
   SELECT
     tx_hash,
     block_number,
@@ -186,18 +185,17 @@ silo as (
   FROM
     {{ ref('silver__silo_liquidations') }}
 
-  {% if is_incremental() and 'silo' not in var('HEAL_MODELS') %}
-  WHERE
-    _inserted_timestamp >= (
-      SELECT
-        MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
-      FROM
-        {{ this }}
-    )
-  {% endif %}
+{% if is_incremental() and 'silo' not in var('HEAL_MODELS') %}
+WHERE
+  _inserted_timestamp >= (
+    SELECT
+      MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
+    FROM
+      {{ this }}
+  )
+{% endif %}
 ),
-
-comp as (
+comp AS (
   SELECT
     tx_hash,
     block_number,
@@ -225,17 +223,17 @@ comp as (
     {{ ref('silver__comp_liquidations') }}
     l
 
-  {% if is_incremental() and 'comp' not in var('HEAL_MODELS') %}
-  WHERE
-    l._inserted_timestamp >= (
-      SELECT
-        MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
-      FROM
-        {{ this }}
-    )
-  {% endif %}
+{% if is_incremental() and 'comp' not in var('HEAL_MODELS') %}
+WHERE
+  l._inserted_timestamp >= (
+    SELECT
+      MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
+    FROM
+      {{ this }}
+  )
+{% endif %}
 ),
-liquidation_union as (
+liquidation_union AS (
   SELECT
     *
   FROM
@@ -266,40 +264,7 @@ liquidation_union as (
   FROM
     silo
 ),
-contracts AS (
-  SELECT
-    *
-  FROM
-    {{ ref('silver__contracts') }} C
-  WHERE
-    C.contract_address IN (
-      SELECT
-        DISTINCT(collateral_asset) AS asset
-      FROM
-        liquidation_union
-    )
-),
-prices AS (
-  SELECT
-    *
-  FROM
-    {{ ref('price__ez_prices_hourly') }}
-    p
-  WHERE
-    token_address IN (
-      SELECT
-        DISTINCT(collateral_asset) AS asset
-      FROM
-        liquidation_union
-    )
-    AND HOUR > (
-      SELECT
-        MIN(block_timestamp)
-      FROM
-        liquidation_union
-    )
-),
-FINAL AS (
+complete_lending_liquidations AS (
   SELECT
     tx_hash,
     block_number,
@@ -340,23 +305,154 @@ FINAL AS (
     A._INSERTED_TIMESTAMP
   FROM
     liquidation_union A
-    LEFT JOIN prices p
+    LEFT JOIN {{ ref('price__ez_prices_hourly') }}
+    p
     ON collateral_asset = p.token_address
     AND DATE_TRUNC(
       'hour',
       block_timestamp
     ) = p.hour
-    LEFT JOIN contracts C
-    ON collateral_asset = C.contract_address
+),
+
+{% if is_incremental() and var(
+  'HEAL_MODEL'
+) %}
+heal_model AS (
+  SELECT
+    tx_hash,
+    block_number,
+    block_timestamp,
+    event_index,
+    origin_from_address,
+    origin_to_address,
+    origin_function_signature,
+    t0.contract_address,
+    event_name,
+    liquidator,
+    borrower,
+    protocol_market,
+    collateral_token,
+    collateral_token_symbol,
+    amount_unadj,
+    amount,
+    CASE
+      WHEN platform <> 'Compound V3' THEN ROUND(
+        amount * p.price,
+        2
+      )
+      ELSE ROUND(
+        amount_usd,
+        2
+      )
+    END AS amount_usd_heal,
+    debt_token,
+    debt_token_symbol,
+    platform,
+    t0.blockchain,
+    t0._LOG_ID,
+    t0._INSERTED_TIMESTAMP
+  FROM
+    {{ this }}
+    t0
+    LEFT JOIN {{ ref('price__ez_prices_hourly') }}
+    p
+    ON t0.collateral_token = p.token_address
+    AND DATE_TRUNC(
+      'hour',
+      block_timestamp
+    ) = p.hour
+  WHERE
+    CONCAT(
+      t0.block_number,
+      '-',
+      t0.platform
+    ) IN (
+      SELECT
+        CONCAT(
+          t1.block_number,
+          '-',
+          t1.platform
+        )
+      FROM
+        {{ this }}
+        t1
+      WHERE
+        t1.amount_usd IS NULL
+        AND t1._inserted_timestamp < (
+          SELECT
+            MAX(
+              _inserted_timestamp
+            ) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
+          FROM
+            {{ this }}
+        )
+        AND EXISTS (
+          SELECT
+            1
+          FROM
+            {{ ref('silver__complete_token_prices') }}
+            p
+          WHERE
+            p._inserted_timestamp > DATEADD('DAY', -14, SYSDATE())
+            AND p.price IS NOT NULL
+            AND p.token_address = t1.collateral_token
+            AND p.hour = DATE_TRUNC(
+              'hour',
+              t1.block_timestamp
+            )
+        )
+      GROUP BY
+        1
+    )
+),
+{% endif %}
+
+FINAL AS (
+  SELECT
+    *
+  FROM
+    complete_lending_liquidations
+
+{% if is_incremental() and var(
+  'HEAL_MODEL'
+) %}
+UNION ALL
+SELECT
+  tx_hash,
+  block_number,
+  block_timestamp,
+  event_index,
+  origin_from_address,
+  origin_to_address,
+  origin_function_signature,
+  contract_address,
+  event_name,
+  liquidator,
+  borrower,
+  protocol_market,
+  collateral_token,
+  collateral_token_symbol,
+  amount_unadj,
+  amount,
+  amount_usd_heal AS amount_usd,
+  debt_token,
+  debt_token_symbol,
+  platform,
+  blockchain,
+  _LOG_ID,
+  _INSERTED_TIMESTAMP
+FROM
+  heal_model
+{% endif %}
 )
 SELECT
-    *,
-    {{ dbt_utils.generate_surrogate_key(
-        ['tx_hash','event_index']
-    ) }} AS complete_lending_liquidations_id,
-    SYSDATE() AS inserted_timestamp,
-    SYSDATE() AS modified_timestamp,
-    '{{ invocation_id }}' AS _invocation_id
+  *,
+  {{ dbt_utils.generate_surrogate_key(
+    ['tx_hash','event_index']
+  ) }} AS complete_lending_liquidations_id,
+  SYSDATE() AS inserted_timestamp,
+  SYSDATE() AS modified_timestamp,
+  '{{ invocation_id }}' AS _invocation_id
 FROM
   FINAL qualify(ROW_NUMBER() over(PARTITION BY _log_id
 ORDER BY

--- a/models/silver/defi/lending/complete_lending/silver__complete_lending_liquidations.sql
+++ b/models/silver/defi/lending/complete_lending/silver__complete_lending_liquidations.sql
@@ -40,7 +40,7 @@ WITH Lodestar AS (
 WHERE
   l._inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
+      MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
     FROM
       {{ this }}
   )
@@ -78,7 +78,7 @@ dforce as (
   WHERE
     l._inserted_timestamp >= (
       SELECT
-        MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
+        MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
       FROM
         {{ this }}
     )
@@ -115,7 +115,7 @@ aave as (
   WHERE
     _inserted_timestamp >= (
       SELECT
-        MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
+        MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
       FROM
         {{ this }}
     )
@@ -152,7 +152,7 @@ radiant as (
   WHERE
     _inserted_timestamp >= (
       SELECT
-        MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
+        MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
       FROM
         {{ this }}
     )
@@ -190,7 +190,7 @@ silo as (
   WHERE
     _inserted_timestamp >= (
       SELECT
-        MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
+        MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
       FROM
         {{ this }}
     )
@@ -229,7 +229,7 @@ comp as (
   WHERE
     l._inserted_timestamp >= (
       SELECT
-        MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
+        MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
       FROM
         {{ this }}
     )

--- a/models/silver/defi/lending/complete_lending/silver__complete_lending_repayments.sql
+++ b/models/silver/defi/lending/complete_lending/silver__complete_lending_repayments.sql
@@ -1,9 +1,10 @@
+-- depends_on: {{ ref('silver__complete_token_prices') }}
 {{ config(
-  materialized = 'incremental',
-  incremental_strategy = 'delete+insert',
-  unique_key = ['block_number','platform'],
-  cluster_by = ['block_timestamp::DATE'],
-  tags = ['reorg','curated']
+    materialized = 'incremental',
+    incremental_strategy = 'delete+insert',
+    unique_key = ['block_number','platform'],
+    cluster_by = ['block_timestamp::DATE'],
+    tags = ['reorg','curated','heal']
 ) }}
 
 WITH aave AS (
@@ -31,11 +32,11 @@ WITH aave AS (
   FROM
     {{ ref('silver__aave_repayments') }}
 
-{% if is_incremental() and 'aave' not in var('HEAL_CURATED_MODEL') %}
+{% if is_incremental() and 'aave' not in var('HEAL_MODELS') %}
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) - INTERVAL '36 hours'
+      MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
     FROM
       {{ this }}
   )
@@ -65,11 +66,11 @@ radiant as (
   FROM
     {{ ref('silver__radiant_repayments') }}
 
-  {% if is_incremental() and 'radiant' not in var('HEAL_CURATED_MODEL') %}
+  {% if is_incremental() and 'radiant' not in var('HEAL_MODELS') %}
   WHERE
     _inserted_timestamp >= (
       SELECT
-        MAX(_inserted_timestamp) - INTERVAL '36 hours'
+        MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
       FROM
         {{ this }}
     )
@@ -99,11 +100,11 @@ lodestar as (
 FROM
   {{ ref('silver__lodestar_repayments') }}
 
-{% if is_incremental() and 'lodestar' not in var('HEAL_CURATED_MODEL') %}
+{% if is_incremental() and 'lodestar' not in var('HEAL_MODELS') %}
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) - INTERVAL '36 hours'
+      MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
     FROM
       {{ this }}
   )
@@ -133,11 +134,11 @@ dforce as (
   FROM
     {{ ref('silver__dforce_repayments') }}
 
-  {% if is_incremental() and 'dforce' not in var('HEAL_CURATED_MODEL') %}
+  {% if is_incremental() and 'dforce' not in var('HEAL_MODELS') %}
   WHERE
     _inserted_timestamp >= (
       SELECT
-        MAX(_inserted_timestamp) - INTERVAL '36 hours'
+        MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
       FROM
         {{ this }}
     )
@@ -167,11 +168,11 @@ comp as (
   FROM
     {{ ref('silver__comp_repayments') }}
 
-  {% if is_incremental() and 'comp' not in var('HEAL_CURATED_MODEL') %}
+  {% if is_incremental() and 'comp' not in var('HEAL_MODELS') %}
   WHERE
     _inserted_timestamp >= (
       SELECT
-        MAX(_inserted_timestamp) - INTERVAL '36 hours'
+        MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
       FROM
         {{ this }}
     )
@@ -201,11 +202,11 @@ silo as (
   FROM
     {{ ref('silver__silo_repayments') }}
 
-  {% if is_incremental() and 'silo' not in var('HEAL_CURATED_MODEL') %}
+  {% if is_incremental() and 'silo' not in var('HEAL_MODELS') %}
   WHERE
     _inserted_timestamp >= (
       SELECT
-        MAX(_inserted_timestamp) - INTERVAL '36 hours'
+        MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
       FROM
         {{ this }}
     )

--- a/models/silver/defi/lending/complete_lending/silver__complete_lending_repayments.sql
+++ b/models/silver/defi/lending/complete_lending/silver__complete_lending_repayments.sql
@@ -1,10 +1,10 @@
 -- depends_on: {{ ref('silver__complete_token_prices') }}
 {{ config(
-    materialized = 'incremental',
-    incremental_strategy = 'delete+insert',
-    unique_key = ['block_number','platform'],
-    cluster_by = ['block_timestamp::DATE'],
-    tags = ['reorg','curated','heal']
+  materialized = 'incremental',
+  incremental_strategy = 'delete+insert',
+  unique_key = ['block_number','platform'],
+  cluster_by = ['block_timestamp::DATE'],
+  tags = ['reorg','curated','heal']
 ) }}
 
 WITH aave AS (
@@ -42,7 +42,7 @@ WHERE
   )
 {% endif %}
 ),
-radiant as (
+radiant AS (
   SELECT
     tx_hash,
     block_number,
@@ -66,39 +66,39 @@ radiant as (
   FROM
     {{ ref('silver__radiant_repayments') }}
 
-  {% if is_incremental() and 'radiant' not in var('HEAL_MODELS') %}
-  WHERE
-    _inserted_timestamp >= (
-      SELECT
-        MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
-      FROM
-        {{ this }}
-    )
-  {% endif %}
+{% if is_incremental() and 'radiant' not in var('HEAL_MODELS') %}
+WHERE
+  _inserted_timestamp >= (
+    SELECT
+      MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
+    FROM
+      {{ this }}
+  )
+{% endif %}
 ),
-lodestar as (
+lodestar AS (
   SELECT
-  tx_hash,
-  block_number,
-  block_timestamp,
-  event_index,
-  origin_from_address,
-  origin_to_address,
-  origin_function_signature,
-  contract_address,
-  repay_contract_address AS token_address,
-  itoken AS protocol_market,
-  amount_unadj,
-  repayed_amount AS amount,
-  repay_contract_symbol AS token_symbol,
-  payer AS payer_address,
-  borrower,
-  platform,
-  'arbitrum' AS blockchain,
-  _LOG_ID,
-  _INSERTED_TIMESTAMP
-FROM
-  {{ ref('silver__lodestar_repayments') }}
+    tx_hash,
+    block_number,
+    block_timestamp,
+    event_index,
+    origin_from_address,
+    origin_to_address,
+    origin_function_signature,
+    contract_address,
+    repay_contract_address AS token_address,
+    itoken AS protocol_market,
+    amount_unadj,
+    repayed_amount AS amount,
+    repay_contract_symbol AS token_symbol,
+    payer AS payer_address,
+    borrower,
+    platform,
+    'arbitrum' AS blockchain,
+    _LOG_ID,
+    _INSERTED_TIMESTAMP
+  FROM
+    {{ ref('silver__lodestar_repayments') }}
 
 {% if is_incremental() and 'lodestar' not in var('HEAL_MODELS') %}
 WHERE
@@ -110,7 +110,7 @@ WHERE
   )
 {% endif %}
 ),
-dforce as (
+dforce AS (
   SELECT
     tx_hash,
     block_number,
@@ -134,17 +134,17 @@ dforce as (
   FROM
     {{ ref('silver__dforce_repayments') }}
 
-  {% if is_incremental() and 'dforce' not in var('HEAL_MODELS') %}
-  WHERE
-    _inserted_timestamp >= (
-      SELECT
-        MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
-      FROM
-        {{ this }}
-    )
-  {% endif %}
+{% if is_incremental() and 'dforce' not in var('HEAL_MODELS') %}
+WHERE
+  _inserted_timestamp >= (
+    SELECT
+      MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
+    FROM
+      {{ this }}
+  )
+{% endif %}
 ),
-comp as (
+comp AS (
   SELECT
     tx_hash,
     block_number,
@@ -168,17 +168,17 @@ comp as (
   FROM
     {{ ref('silver__comp_repayments') }}
 
-  {% if is_incremental() and 'comp' not in var('HEAL_MODELS') %}
-  WHERE
-    _inserted_timestamp >= (
-      SELECT
-        MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
-      FROM
-        {{ this }}
-    )
-  {% endif %}
+{% if is_incremental() and 'comp' not in var('HEAL_MODELS') %}
+WHERE
+  _inserted_timestamp >= (
+    SELECT
+      MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
+    FROM
+      {{ this }}
+  )
+{% endif %}
 ),
-silo as (
+silo AS (
   SELECT
     tx_hash,
     block_number,
@@ -202,17 +202,17 @@ silo as (
   FROM
     {{ ref('silver__silo_repayments') }}
 
-  {% if is_incremental() and 'silo' not in var('HEAL_MODELS') %}
-  WHERE
-    _inserted_timestamp >= (
-      SELECT
-        MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
-      FROM
-        {{ this }}
-    )
-  {% endif %}
+{% if is_incremental() and 'silo' not in var('HEAL_MODELS') %}
+WHERE
+  _inserted_timestamp >= (
+    SELECT
+      MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
+    FROM
+      {{ this }}
+  )
+{% endif %}
 ),
-repayments as (
+repayments AS (
   SELECT
     *
   FROM
@@ -243,7 +243,7 @@ repayments as (
   FROM
     silo
 ),
-FINAL AS (
+complete_lending_repayments AS (
   SELECT
     tx_hash,
     block_number,
@@ -282,17 +282,137 @@ FINAL AS (
       'hour',
       block_timestamp
     ) = p.hour
-    LEFT JOIN {{ ref('silver__contracts') }} C
-    ON A.token_address = C.contract_address
+),
+
+{% if is_incremental() and var(
+  'HEAL_MODEL'
+) %}
+heal_model AS (
+  SELECT
+    tx_hash,
+    block_number,
+    block_timestamp,
+    event_index,
+    origin_from_address,
+    origin_to_address,
+    origin_function_signature,
+    t0.contract_address,
+    event_name,
+    protocol_market,
+    payer,
+    borrower,
+    t0.token_address,
+    t0.token_symbol,
+    amount_unadj,
+    amount,
+    ROUND(
+      amount * p.price,
+      2
+    ) AS amount_usd_heal,
+    platform,
+    t0.blockchain,
+    t0._LOG_ID,
+    t0._INSERTED_TIMESTAMP
+  FROM
+    {{ this }}
+    t0
+    LEFT JOIN {{ ref('price__ez_prices_hourly') }}
+    p
+    ON t0.token_address = p.token_address
+    AND DATE_TRUNC(
+      'hour',
+      block_timestamp
+    ) = p.hour
+  WHERE
+    CONCAT(
+      t0.block_number,
+      '-',
+      t0.platform
+    ) IN (
+      SELECT
+        CONCAT(
+          t1.block_number,
+          '-',
+          t1.platform
+        )
+      FROM
+        {{ this }}
+        t1
+      WHERE
+        t1.amount_usd IS NULL
+        AND t1._inserted_timestamp < (
+          SELECT
+            MAX(
+              _inserted_timestamp
+            ) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
+          FROM
+            {{ this }}
+        )
+        AND EXISTS (
+          SELECT
+            1
+          FROM
+            {{ ref('silver__complete_token_prices') }}
+            p
+          WHERE
+            p._inserted_timestamp > DATEADD('DAY', -14, SYSDATE())
+            AND p.price IS NOT NULL
+            AND p.token_address = t1.token_address
+            AND p.hour = DATE_TRUNC(
+              'hour',
+              t1.block_timestamp
+            )
+        )
+      GROUP BY
+        1
+    )
+),
+{% endif %}
+
+FINAL AS (
+  SELECT
+    *
+  FROM
+    complete_lending_repayments
+
+{% if is_incremental() and var(
+  'HEAL_MODEL'
+) %}
+UNION ALL
+SELECT
+  tx_hash,
+  block_number,
+  block_timestamp,
+  event_index,
+  origin_from_address,
+  origin_to_address,
+  origin_function_signature,
+  contract_address,
+  event_name,
+  protocol_market,
+  payer,
+  borrower,
+  token_address,
+  token_symbol,
+  amount_unadj,
+  amount,
+  amount_usd_heal AS amount_usd,
+  platform,
+  blockchain,
+  _LOG_ID,
+  _INSERTED_TIMESTAMP
+FROM
+  heal_model
+{% endif %}
 )
 SELECT
-    *,
-    {{ dbt_utils.generate_surrogate_key(
-        ['tx_hash','event_index']
-    ) }} AS complete_lending_repayments_id,
-    SYSDATE() AS inserted_timestamp,
-    SYSDATE() AS modified_timestamp,
-    '{{ invocation_id }}' AS _invocation_id
+  *,
+  {{ dbt_utils.generate_surrogate_key(
+    ['tx_hash','event_index']
+  ) }} AS complete_lending_repayments_id,
+  SYSDATE() AS inserted_timestamp,
+  SYSDATE() AS modified_timestamp,
+  '{{ invocation_id }}' AS _invocation_id
 FROM
   FINAL qualify(ROW_NUMBER() over(PARTITION BY _log_id
 ORDER BY

--- a/models/silver/defi/lending/complete_lending/silver__complete_lending_repayments.sql
+++ b/models/silver/defi/lending/complete_lending/silver__complete_lending_repayments.sql
@@ -36,7 +36,7 @@ WITH aave AS (
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
+      MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
     FROM
       {{ this }}
   )
@@ -70,7 +70,7 @@ radiant as (
   WHERE
     _inserted_timestamp >= (
       SELECT
-        MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
+        MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
       FROM
         {{ this }}
     )
@@ -104,7 +104,7 @@ FROM
 WHERE
   _inserted_timestamp >= (
     SELECT
-      MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
+      MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
     FROM
       {{ this }}
   )
@@ -138,7 +138,7 @@ dforce as (
   WHERE
     _inserted_timestamp >= (
       SELECT
-        MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
+        MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
       FROM
         {{ this }}
     )
@@ -172,7 +172,7 @@ comp as (
   WHERE
     _inserted_timestamp >= (
       SELECT
-        MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
+        MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
       FROM
         {{ this }}
     )
@@ -206,7 +206,7 @@ silo as (
   WHERE
     _inserted_timestamp >= (
       SELECT
-        MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
+        MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
       FROM
         {{ this }}
     )

--- a/models/silver/defi/lending/complete_lending/silver__complete_lending_withdraws.sql
+++ b/models/silver/defi/lending/complete_lending/silver__complete_lending_withdraws.sql
@@ -43,7 +43,7 @@ WHERE
     )
 {% endif %}
 ),
-radiant as (
+radiant AS (
     SELECT
         tx_hash,
         block_number,
@@ -66,19 +66,19 @@ radiant as (
     FROM
         {{ ref('silver__radiant_withdraws') }}
 
-    {% if is_incremental() and 'radiant' not in var('HEAL_MODELS') %}
-    WHERE
-        _inserted_timestamp >= (
-            SELECT
-                MAX(
-                    _inserted_timestamp
-                ) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
-            FROM
-                {{ this }}
-        )
-    {% endif %}
+{% if is_incremental() and 'radiant' not in var('HEAL_MODELS') %}
+WHERE
+    _inserted_timestamp >= (
+        SELECT
+            MAX(
+                _inserted_timestamp
+            ) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
+        FROM
+            {{ this }}
+    )
+{% endif %}
 ),
-comp as (
+comp AS (
     SELECT
         tx_hash,
         block_number,
@@ -101,19 +101,19 @@ comp as (
     FROM
         {{ ref('silver__comp_withdraws') }}
 
-    {% if is_incremental() and 'comp' not in var('HEAL_MODELS') %}
-    WHERE
-        _inserted_timestamp >= (
-            SELECT
-                MAX(
-                    _inserted_timestamp
-                ) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
-            FROM
-                {{ this }}
-        )
-    {% endif %}
+{% if is_incremental() and 'comp' not in var('HEAL_MODELS') %}
+WHERE
+    _inserted_timestamp >= (
+        SELECT
+            MAX(
+                _inserted_timestamp
+            ) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
+        FROM
+            {{ this }}
+    )
+{% endif %}
 ),
-lodestar as (
+lodestar AS (
     SELECT
         tx_hash,
         block_number,
@@ -136,19 +136,19 @@ lodestar as (
     FROM
         {{ ref('silver__lodestar_withdraws') }}
 
-    {% if is_incremental() and 'lodestar' not in var('HEAL_MODELS') %}
-    WHERE
-        _inserted_timestamp >= (
-            SELECT
-                MAX(
-                    _inserted_timestamp
-                ) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
-            FROM
-                {{ this }}
-        )
-    {% endif %}
+{% if is_incremental() and 'lodestar' not in var('HEAL_MODELS') %}
+WHERE
+    _inserted_timestamp >= (
+        SELECT
+            MAX(
+                _inserted_timestamp
+            ) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
+        FROM
+            {{ this }}
+    )
+{% endif %}
 ),
-dforce as (
+dforce AS (
     SELECT
         tx_hash,
         block_number,
@@ -171,19 +171,19 @@ dforce as (
     FROM
         {{ ref('silver__dforce_withdraws') }}
 
-    {% if is_incremental() and 'dforce' not in var('HEAL_MODELS') %}
-    WHERE
-        _inserted_timestamp >= (
-            SELECT
-                MAX(
-                    _inserted_timestamp
-                ) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
-            FROM
-                {{ this }}
-        )
-    {% endif %}
+{% if is_incremental() and 'dforce' not in var('HEAL_MODELS') %}
+WHERE
+    _inserted_timestamp >= (
+        SELECT
+            MAX(
+                _inserted_timestamp
+            ) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
+        FROM
+            {{ this }}
+    )
+{% endif %}
 ),
-silo as (
+silo AS (
     SELECT
         tx_hash,
         block_number,
@@ -206,50 +206,50 @@ silo as (
     FROM
         {{ ref('silver__silo_withdraws') }}
 
-    {% if is_incremental() and 'silo' not in var('HEAL_MODELS') %}
-    WHERE
-        _inserted_timestamp >= (
-            SELECT
-                MAX(
-                    _inserted_timestamp
-                ) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
-            FROM
-                {{ this }}
-        )
-    {% endif %}
+{% if is_incremental() and 'silo' not in var('HEAL_MODELS') %}
+WHERE
+    _inserted_timestamp >= (
+        SELECT
+            MAX(
+                _inserted_timestamp
+            ) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
+        FROM
+            {{ this }}
+    )
+{% endif %}
 ),
-withdraws as (
-  SELECT
-    *
-  FROM
-    aave
-  UNION ALL
-  SELECT
-    *
-  FROM
-    radiant
-  UNION ALL
-  SELECT
-    *
-  FROM
-    comp
-  UNION ALL
-  SELECT
-    *
-  FROM
-    dforce
-  UNION ALL
-  SELECT
-    *
-  FROM
-    lodestar
-  UNION ALL
-  SELECT
-    *
-  FROM
-    silo
+withdraws AS (
+    SELECT
+        *
+    FROM
+        aave
+    UNION ALL
+    SELECT
+        *
+    FROM
+        radiant
+    UNION ALL
+    SELECT
+        *
+    FROM
+        comp
+    UNION ALL
+    SELECT
+        *
+    FROM
+        dforce
+    UNION ALL
+    SELECT
+        *
+    FROM
+        lodestar
+    UNION ALL
+    SELECT
+        *
+    FROM
+        silo
 ),
-FINAL AS (
+complete_lending_withdraws AS (
     SELECT
         tx_hash,
         block_number,
@@ -287,8 +287,126 @@ FINAL AS (
             'hour',
             block_timestamp
         ) = p.hour
-        LEFT JOIN {{ ref('silver__contracts') }} C
-        ON A.token_address = C.contract_address
+),
+
+{% if is_incremental() and var(
+    'HEAL_MODEL'
+) %}
+heal_model AS (
+    SELECT
+        tx_hash,
+        block_number,
+        block_timestamp,
+        event_index,
+        origin_from_address,
+        origin_to_address,
+        origin_function_signature,
+        t0.contract_address,
+        event_name,
+        protocol_market,
+        depositor,
+        t0.token_address,
+        t0.token_symbol,
+        amount_unadj,
+        amount,
+        ROUND(
+            amount * p.price,
+            2
+        ) AS amount_usd_heal,
+        platform,
+        t0.blockchain,
+        t0._log_id,
+        t0._inserted_timestamp
+    FROM
+        {{ this }}
+        t0
+        LEFT JOIN {{ ref('price__ez_prices_hourly') }}
+        p
+        ON t0.token_address = p.token_address
+        AND DATE_TRUNC(
+            'hour',
+            block_timestamp
+        ) = p.hour
+    WHERE
+        CONCAT(
+            t0.block_number,
+            '-',
+            t0.platform
+        ) IN (
+            SELECT
+                CONCAT(
+                    t1.block_number,
+                    '-',
+                    t1.platform
+                )
+            FROM
+                {{ this }}
+                t1
+            WHERE
+                t1.amount_usd IS NULL
+                AND t1._inserted_timestamp < (
+                    SELECT
+                        MAX(
+                            _inserted_timestamp
+                        ) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
+                    FROM
+                        {{ this }}
+                )
+                AND EXISTS (
+                    SELECT
+                        1
+                    FROM
+                        {{ ref('silver__complete_token_prices') }}
+                        p
+                    WHERE
+                        p._inserted_timestamp > DATEADD('DAY', -14, SYSDATE())
+                        AND p.price IS NOT NULL
+                        AND p.token_address = t1.token_address
+                        AND p.hour = DATE_TRUNC(
+                            'hour',
+                            t1.block_timestamp
+                        )
+                )
+            GROUP BY
+                1
+        )
+),
+{% endif %}
+
+FINAL AS (
+    SELECT
+        *
+    FROM
+        complete_lending_withdraws
+
+{% if is_incremental() and var(
+    'HEAL_MODEL'
+) %}
+UNION ALL
+SELECT
+    tx_hash,
+    block_number,
+    block_timestamp,
+    event_index,
+    origin_from_address,
+    origin_to_address,
+    origin_function_signature,
+    contract_address,
+    event_name,
+    protocol_market,
+    depositor,
+    token_address,
+    token_symbol,
+    amount_unadj,
+    amount,
+    amount_usd_heal AS amount_usd,
+    platform,
+    blockchain,
+    _log_id,
+    _inserted_timestamp
+FROM
+    heal_model
+{% endif %}
 )
 SELECT
     *,

--- a/models/silver/defi/lending/complete_lending/silver__complete_lending_withdraws.sql
+++ b/models/silver/defi/lending/complete_lending/silver__complete_lending_withdraws.sql
@@ -1,9 +1,10 @@
+-- depends_on: {{ ref('silver__complete_token_prices') }}
 {{ config(
     materialized = 'incremental',
     incremental_strategy = 'delete+insert',
     unique_key = ['block_number','platform'],
     cluster_by = ['block_timestamp::DATE'],
-    tags = ['reorg','curated']
+    tags = ['reorg','curated','heal']
 ) }}
 
 WITH aave AS (
@@ -30,13 +31,13 @@ WITH aave AS (
     FROM
         {{ ref('silver__aave_withdraws') }}
 
-{% if is_incremental() and 'aave' not in var('HEAL_CURATED_MODEL') %}
+{% if is_incremental() and 'aave' not in var('HEAL_MODELS') %}
 WHERE
     _inserted_timestamp >= (
         SELECT
             MAX(
                 _inserted_timestamp
-            ) - INTERVAL '36 hours'
+            ) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
         FROM
             {{ this }}
     )
@@ -65,13 +66,13 @@ radiant as (
     FROM
         {{ ref('silver__radiant_withdraws') }}
 
-    {% if is_incremental() and 'radiant' not in var('HEAL_CURATED_MODEL') %}
+    {% if is_incremental() and 'radiant' not in var('HEAL_MODELS') %}
     WHERE
         _inserted_timestamp >= (
             SELECT
                 MAX(
                     _inserted_timestamp
-                ) - INTERVAL '36 hours'
+                ) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
             FROM
                 {{ this }}
         )
@@ -100,13 +101,13 @@ comp as (
     FROM
         {{ ref('silver__comp_withdraws') }}
 
-    {% if is_incremental() and 'comp' not in var('HEAL_CURATED_MODEL') %}
+    {% if is_incremental() and 'comp' not in var('HEAL_MODELS') %}
     WHERE
         _inserted_timestamp >= (
             SELECT
                 MAX(
                     _inserted_timestamp
-                ) - INTERVAL '36 hours'
+                ) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
             FROM
                 {{ this }}
         )
@@ -135,13 +136,13 @@ lodestar as (
     FROM
         {{ ref('silver__lodestar_withdraws') }}
 
-    {% if is_incremental() and 'lodestar' not in var('HEAL_CURATED_MODEL') %}
+    {% if is_incremental() and 'lodestar' not in var('HEAL_MODELS') %}
     WHERE
         _inserted_timestamp >= (
             SELECT
                 MAX(
                     _inserted_timestamp
-                ) - INTERVAL '36 hours'
+                ) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
             FROM
                 {{ this }}
         )
@@ -170,13 +171,13 @@ dforce as (
     FROM
         {{ ref('silver__dforce_withdraws') }}
 
-    {% if is_incremental() and 'dforce' not in var('HEAL_CURATED_MODEL') %}
+    {% if is_incremental() and 'dforce' not in var('HEAL_MODELS') %}
     WHERE
         _inserted_timestamp >= (
             SELECT
                 MAX(
                     _inserted_timestamp
-                ) - INTERVAL '36 hours'
+                ) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
             FROM
                 {{ this }}
         )
@@ -205,13 +206,13 @@ silo as (
     FROM
         {{ ref('silver__silo_withdraws') }}
 
-    {% if is_incremental() and 'silo' not in var('HEAL_CURATED_MODEL') %}
+    {% if is_incremental() and 'silo' not in var('HEAL_MODELS') %}
     WHERE
         _inserted_timestamp >= (
             SELECT
                 MAX(
                     _inserted_timestamp
-                ) - INTERVAL '36 hours'
+                ) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
             FROM
                 {{ this }}
         )

--- a/models/silver/defi/lending/complete_lending/silver__complete_lending_withdraws.sql
+++ b/models/silver/defi/lending/complete_lending/silver__complete_lending_withdraws.sql
@@ -37,7 +37,7 @@ WHERE
         SELECT
             MAX(
                 _inserted_timestamp
-            ) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
+            ) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
         FROM
             {{ this }}
     )
@@ -72,7 +72,7 @@ radiant as (
             SELECT
                 MAX(
                     _inserted_timestamp
-                ) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
+                ) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
             FROM
                 {{ this }}
         )
@@ -107,7 +107,7 @@ comp as (
             SELECT
                 MAX(
                     _inserted_timestamp
-                ) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
+                ) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
             FROM
                 {{ this }}
         )
@@ -142,7 +142,7 @@ lodestar as (
             SELECT
                 MAX(
                     _inserted_timestamp
-                ) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
+                ) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
             FROM
                 {{ this }}
         )
@@ -177,7 +177,7 @@ dforce as (
             SELECT
                 MAX(
                     _inserted_timestamp
-                ) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
+                ) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
             FROM
                 {{ this }}
         )
@@ -212,7 +212,7 @@ silo as (
             SELECT
                 MAX(
                     _inserted_timestamp
-                ) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
+                ) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
             FROM
                 {{ this }}
         )

--- a/models/silver/defi/lending/compound/silver__comp_borrows.sql
+++ b/models/silver/defi/lending/compound/silver__comp_borrows.sql
@@ -45,6 +45,7 @@ WITH borrow AS (
             LOWER('0xA5EDBDD9646f8dFF606d7448e414884C7d905dCA'),
             LOWER('0x9c4ec768c28520B50860ea7a15bd7213a9fF58bf')
         )
+        AND tx_status = 'SUCCESS'
 
 {% if is_incremental() %}
 AND l._inserted_timestamp >= (

--- a/models/silver/defi/lending/compound/silver__comp_deposits.sql
+++ b/models/silver/defi/lending/compound/silver__comp_deposits.sql
@@ -39,6 +39,7 @@ WITH supply AS (
         ON asset = C.contract_address
     WHERE
         topics [0] = '0xfa56f7b24f17183d81894d3ac2ee654e3c26388d17a28dbd9549b8114304e1f4' --SupplyCollateral
+        AND tx_status = 'SUCCESS'
 
 {% if is_incremental() %}
 AND l._inserted_timestamp >= (

--- a/models/silver/defi/lending/compound/silver__comp_liquidations.sql
+++ b/models/silver/defi/lending/compound/silver__comp_liquidations.sql
@@ -43,6 +43,7 @@ WITH liquidations AS (
         ON asset = C.contract_address
     WHERE
         topics [0] = '0x9850ab1af75177e4a9201c65a2cf7976d5d28e40ef63494b44366f86b2f9412e' --AbsorbCollateral
+        AND tx_status = 'SUCCESS'
 
 {% if is_incremental() %}
 AND l._inserted_timestamp >= (

--- a/models/silver/defi/lending/compound/silver__comp_repayments.sql
+++ b/models/silver/defi/lending/compound/silver__comp_repayments.sql
@@ -48,6 +48,7 @@ WITH repayments AS (
             LOWER('0xA5EDBDD9646f8dFF606d7448e414884C7d905dCA'),
             LOWER('0x9c4ec768c28520B50860ea7a15bd7213a9fF58bf')
         )
+        AND tx_status = 'SUCCESS'
 
 {% if is_incremental() %}
 AND l._inserted_timestamp >= (

--- a/models/silver/defi/lending/compound/silver__comp_withdraws.sql
+++ b/models/silver/defi/lending/compound/silver__comp_withdraws.sql
@@ -38,6 +38,7 @@ WITH withdraw AS (
         ON token_address = C.contract_address
     WHERE
         topics [0] = '0xd6d480d5b3068db003533b170d67561494d72e3bf9fa40a266471351ebba9e16' --WithdrawCollateral
+        AND tx_status = 'SUCCESS'
 
 {% if is_incremental() %}
 AND l._inserted_timestamp >= (

--- a/models/silver/defi/lending/dforce/silver__dforce_borrows.sql
+++ b/models/silver/defi/lending/dforce/silver__dforce_borrows.sql
@@ -55,6 +55,7 @@ dforce_borrows AS (
         asset_details
     )
     AND topics [0] :: STRING = '0x2dd79f4fccfd18c360ce7f9132f3621bf05eee18f995224badb32d17f172df73'
+    AND tx_status = 'SUCCESS'
 
 {% if is_incremental() %}
 AND _inserted_timestamp >= (

--- a/models/silver/defi/lending/dforce/silver__dforce_deposits.sql
+++ b/models/silver/defi/lending/dforce/silver__dforce_deposits.sql
@@ -52,6 +52,7 @@ dforce_deposits AS (
         asset_details
     )
     AND topics [0] :: STRING = '0x2f00e3cdd69a77be7ed215ec7b2a36784dd158f921fca79ac29deffa353fe6ee'
+    AND tx_status = 'SUCCESS'
 
 {% if is_incremental() %}
 AND _inserted_timestamp >= (

--- a/models/silver/defi/lending/dforce/silver__dforce_liquidations.sql
+++ b/models/silver/defi/lending/dforce/silver__dforce_liquidations.sql
@@ -55,6 +55,7 @@ dforce_liquidations AS (
         asset_details
     )
     AND topics [0] :: STRING = '0x298637f684da70674f26509b10f07ec2fbc77a335ab1e7d6215a4b2484d8bb52'
+    AND tx_status = 'SUCCESS'
 
 {% if is_incremental() %}
 AND _inserted_timestamp >= (

--- a/models/silver/defi/lending/dforce/silver__dforce_repayments.sql
+++ b/models/silver/defi/lending/dforce/silver__dforce_repayments.sql
@@ -50,6 +50,7 @@ dforce_repayments AS (
         asset_details
     )
     AND topics [0] :: STRING = '0x6fadbf7329d21f278e724fa0d4511001a158f2a97ee35c5bc4cf8b64417399ef'
+    AND tx_status = 'SUCCESS'
 
 {% if is_incremental() %}
 AND _inserted_timestamp >= (

--- a/models/silver/defi/lending/dforce/silver__dforce_withdraws.sql
+++ b/models/silver/defi/lending/dforce/silver__dforce_withdraws.sql
@@ -52,6 +52,7 @@ dforce_redemptions AS (
                 asset_details
         )
         AND topics [0] :: STRING = '0x3f693fff038bb8a046aa76d9516190ac7444f7d69cf952c4cbdc086fdef2d6fc'
+        AND tx_status = 'SUCCESS'
 
 {% if is_incremental() %}
 AND _inserted_timestamp >= (

--- a/models/silver/defi/lending/lodestar/silver__lodestar_borrows.sql
+++ b/models/silver/defi/lending/lodestar/silver__lodestar_borrows.sql
@@ -55,6 +55,7 @@ lodestar_borrows AS (
         asset_details
     )
     AND topics [0] :: STRING = '0x2dd79f4fccfd18c360ce7f9132f3621bf05eee18f995224badb32d17f172df73'
+    AND tx_status = 'SUCCESS'
 
 {% if is_incremental() %}
 AND _inserted_timestamp >= (

--- a/models/silver/defi/lending/lodestar/silver__lodestar_deposits.sql
+++ b/models/silver/defi/lending/lodestar/silver__lodestar_deposits.sql
@@ -52,6 +52,7 @@ lodestar_deposits AS (
         asset_details
     )
     AND topics [0] :: STRING = '0x4c209b5fc8ad50758f13e2e1088ba56a560dff690a1c6fef26394f4c03821c4f'
+    AND tx_status = 'SUCCESS'
 
 {% if is_incremental() %}
 AND _inserted_timestamp >= (

--- a/models/silver/defi/lending/lodestar/silver__lodestar_liquidations.sql
+++ b/models/silver/defi/lending/lodestar/silver__lodestar_liquidations.sql
@@ -55,6 +55,7 @@ lodestar_liquidations AS (
         asset_details
     )
     AND topics [0] :: STRING = '0x298637f684da70674f26509b10f07ec2fbc77a335ab1e7d6215a4b2484d8bb52'
+    AND tx_status = 'SUCCESS'
 
 {% if is_incremental() %}
 AND _inserted_timestamp >= (

--- a/models/silver/defi/lending/lodestar/silver__lodestar_repayments.sql
+++ b/models/silver/defi/lending/lodestar/silver__lodestar_repayments.sql
@@ -50,6 +50,7 @@ lodestar_repayments AS (
         asset_details
     )
     AND topics [0] :: STRING = '0x6fadbf7329d21f278e724fa0d4511001a158f2a97ee35c5bc4cf8b64417399ef'
+    AND tx_status = 'SUCCESS'
 
 {% if is_incremental() %}
 AND _inserted_timestamp >= (

--- a/models/silver/defi/lending/lodestar/silver__lodestar_withdraws.sql
+++ b/models/silver/defi/lending/lodestar/silver__lodestar_withdraws.sql
@@ -52,6 +52,7 @@ lodestar_redemptions AS (
                 asset_details
         )
         AND topics [0] :: STRING = '0xe5b754fb1abb7f01b499791d0b820ae3b6af3424ac1c59768edb53f4ec31a929'
+        AND tx_status = 'SUCCESS'
 
 {% if is_incremental() %}
 AND _inserted_timestamp >= (

--- a/models/silver/nft/sales/silver__complete_nft_sales.sql
+++ b/models/silver/nft/sales/silver__complete_nft_sales.sql
@@ -42,7 +42,7 @@ WITH nft_base_models AS (
 WHERE
     _inserted_timestamp >= (
         SELECT
-            MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
+            MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
         FROM
             {{ this }}
     )
@@ -82,7 +82,7 @@ FROM
 WHERE
     _inserted_timestamp >= (
         SELECT
-            MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
+            MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
         FROM
             {{ this }}
     )
@@ -122,7 +122,7 @@ FROM
 WHERE
     _inserted_timestamp >= (
         SELECT
-            MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
+            MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
         FROM
             {{ this }}
     )
@@ -162,7 +162,7 @@ FROM
 WHERE
     _inserted_timestamp >= (
         SELECT
-            MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
+            MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
         FROM
             {{ this }}
     )
@@ -202,7 +202,7 @@ FROM
 WHERE
     _inserted_timestamp >= (
         SELECT
-            MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
+            MAX(_inserted_timestamp) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
         FROM
             {{ this }}
     )
@@ -518,7 +518,7 @@ heal_model AS (
                         SELECT
                             MAX(
                                 _inserted_timestamp
-                            ) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
+                            ) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
                         FROM
                             {{ this }}
                     )
@@ -546,7 +546,7 @@ heal_model AS (
                             SELECT
                                 MAX(
                                     _inserted_timestamp
-                                ) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
+                                ) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
                             FROM
                                 {{ this }}
                         )
@@ -585,7 +585,7 @@ heal_model AS (
                                     SELECT
                                         MAX(
                                             _inserted_timestamp
-                                        ) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
+                                        ) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
                                     FROM
                                         {{ this }}
                                 )

--- a/models/silver/nft/sales/silver__complete_nft_sales.sql
+++ b/models/silver/nft/sales/silver__complete_nft_sales.sql
@@ -38,11 +38,11 @@ WITH nft_base_models AS (
     FROM
         {{ ref('silver__seaport_1_1_sales') }}
 
-{% if is_incremental() and 'seaport_1_1' not in var('HEAL_CURATED_MODEL') %}
+{% if is_incremental() and 'seaport_1_1' not in var('HEAL_MODELS') %}
 WHERE
     _inserted_timestamp >= (
         SELECT
-            MAX(_inserted_timestamp) - INTERVAL '36 hours'
+            MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
         FROM
             {{ this }}
     )
@@ -78,11 +78,11 @@ SELECT
 FROM
     {{ ref('silver__seaport_1_4_sales') }}
 
-{% if is_incremental() and 'seaport_1_4' not in var('HEAL_CURATED_MODEL') %}
+{% if is_incremental() and 'seaport_1_4' not in var('HEAL_MODELS') %}
 WHERE
     _inserted_timestamp >= (
         SELECT
-            MAX(_inserted_timestamp) - INTERVAL '36 hours'
+            MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
         FROM
             {{ this }}
     )
@@ -118,11 +118,11 @@ SELECT
 FROM
     {{ ref('silver__seaport_1_5_sales') }}
 
-{% if is_incremental() and 'seaport_1_5' not in var('HEAL_CURATED_MODEL') %}
+{% if is_incremental() and 'seaport_1_5' not in var('HEAL_MODELS') %}
 WHERE
     _inserted_timestamp >= (
         SELECT
-            MAX(_inserted_timestamp) - INTERVAL '36 hours'
+            MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
         FROM
             {{ this }}
     )
@@ -158,11 +158,11 @@ SELECT
 FROM
     {{ ref('silver__treasure_sales') }}
 
-{% if is_incremental() and 'treasure' not in var('HEAL_CURATED_MODEL') %}
+{% if is_incremental() and 'treasure' not in var('HEAL_MODELS') %}
 WHERE
     _inserted_timestamp >= (
         SELECT
-            MAX(_inserted_timestamp) - INTERVAL '36 hours'
+            MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
         FROM
             {{ this }}
     )
@@ -198,11 +198,11 @@ SELECT
 FROM
     {{ ref('silver__seaport_1_6_sales') }}
 
-{% if is_incremental() and 'seaport_1_6' not in var('HEAL_CURATED_MODEL') %}
+{% if is_incremental() and 'seaport_1_6' not in var('HEAL_MODELS') %}
 WHERE
     _inserted_timestamp >= (
         SELECT
-            MAX(_inserted_timestamp) - INTERVAL '36 hours'
+            MAX(_inserted_timestamp) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
         FROM
             {{ this }}
     )
@@ -518,7 +518,7 @@ heal_model AS (
                         SELECT
                             MAX(
                                 _inserted_timestamp
-                            ) - INTERVAL '36 hours'
+                            ) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
                         FROM
                             {{ this }}
                     )
@@ -546,7 +546,7 @@ heal_model AS (
                             SELECT
                                 MAX(
                                     _inserted_timestamp
-                                ) - INTERVAL '36 hours'
+                                ) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
                             FROM
                                 {{ this }}
                         )
@@ -585,7 +585,7 @@ heal_model AS (
                                     SELECT
                                         MAX(
                                             _inserted_timestamp
-                                        ) - INTERVAL '36 hours'
+                                        ) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
                                     FROM
                                         {{ this }}
                                 )

--- a/models/silver/nft/silver__nft_transfers.sql
+++ b/models/silver/nft/silver__nft_transfers.sql
@@ -362,7 +362,7 @@ heal_model AS (
                     SELECT
                         MAX(
                             _inserted_timestamp
-                        ) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
+                        ) - INTERVAL '{{ var("LOOKBACK", "4 hours") }}'
                     FROM
                         {{ this }}
                 )

--- a/models/silver/nft/silver__nft_transfers.sql
+++ b/models/silver/nft/silver__nft_transfers.sql
@@ -362,7 +362,7 @@ heal_model AS (
                     SELECT
                         MAX(
                             _inserted_timestamp
-                        ) - INTERVAL '36 hours'
+                        ) - INTERVAL '{{ var(' lookback ', ' 4 hours ') }}'
                     FROM
                         {{ this }}
                 )


### PR DESCRIPTION
Requires delete for dupes related to version changes after first heal on dex swaps

1. Added heal logic for all complete curated models 
2. Standardized CTE names in complete curated models
3. Rebuilt dex swaps to enable heal logic, cleaned up other defi models
4. Revamped README for vars
5. Changed `HEAL_CURATED_MODEL` var to `HEAL_MODELS`
6. Reduced lookbacks to 4 hours and added `LOOKBACK` var

`dbt run -m models/silver/defi/dex/silver_dex__complete_dex_liquidity_pools.sql --full-refresh && dbt run -m models/silver/defi/dex/silver_dex__complete_dex_swaps.sql models/gold/defi`