### PR TITLE
An 5822 - Update fsc utils package + fix ABI request

### DIFF
--- a/models/bronze/api_udf/bronze_api__contract_abis.sql
+++ b/models/bronze/api_udf/bronze_api__contract_abis.sql
@@ -50,7 +50,18 @@ row_nos AS (
 ),
 batched AS ({% for item in range(501) %}
 SELECT
-    rn.contract_address, live.udf_api('GET', CONCAT('https://api.arbiscan.io/api?module=contract&action=getabi&address=', rn.contract_address, '&apikey={key}'),{ 'User-Agent': 'FlipsideStreamline' },{}, 'Vault/prod/block_explorers/arbiscan') AS abi_data, SYSDATE() AS _inserted_timestamp
+    rn.contract_address, 
+    live.udf_api(
+    'GET', 
+    CONCAT('https://api.arbiscan.io/api?module=contract&action=getabi&address=', rn.contract_address, '&apikey={key}'),
+    OBJECT_CONSTRUCT(
+            'Content-Type', 'application/json',
+            'fsc-quantum-state', 'livequery'
+        ),
+    NULL, 
+    'Vault/prod/block_explorers/arbiscan'
+    )AS abi_data, 
+    SYSDATE() AS _inserted_timestamp
 FROM
     row_nos rn
 WHERE

--- a/models/bronze/api_udf/bronze_api__contract_abis.sql
+++ b/models/bronze/api_udf/bronze_api__contract_abis.sql
@@ -59,7 +59,7 @@ SELECT
             'fsc-quantum-state', 'livequery'
         ),
     NULL, 
-    'Vault/prod/block_explorers/arbiscan'
+    'Vault/prod/block_explorers/arbitrum_scan'
     )AS abi_data, 
     SYSDATE() AS _inserted_timestamp
 FROM

--- a/packages.yml
+++ b/packages.yml
@@ -6,7 +6,7 @@ packages:
   - package: dbt-labs/dbt_utils
     version: 1.0.0
   - git: https://github.com/FlipsideCrypto/fsc-utils.git
-    revision: v1.31.0
+    revision: v1.33.1
   - package: get-select/dbt_snowflake_query_tags
     version: [">=2.0.0", "<3.0.0"]
   - git: https://github.com/FlipsideCrypto/fsc-evm.git


### PR DESCRIPTION
steps:

--delete from arbitrum.bronze_api.contract_abis
--where _inserted_timestamp >= '2025-02-21 00:31:21.944';

-- DROP SCHEMA arbitrum._live;
-- DROP SCHEMA arbitrum._utils;
-- DROP SCHEMA arbitrum.live;
-- DROP SCHEMA arbitrum.utils;

-- run with dbtcloud role in prod // internal dev role in dev 
dbt run -m livequery_models.deploy.core --vars '{UPDATE_UDFS_AND_SPS: true}' --target prod

-- SHOW GRANTS ON FUNCTION arbitrum_dev._LIVE.UDF_API(VARCHAR, VARCHAR, OBJECT, VARIANT, VARCHAR, VARCHAR);
--  GRANT USAGE ON SCHEMA arbitrum_dev._live TO AWS_LAMBDA_arbitrum_API;
--  GRANT USAGE ON ALL FUNCTIONS IN SCHEMA arbitrum_dev._live TO AWS_LAMBDA_arbitrum_API;
--  GRANT USAGE ON SCHEMA arbitrum_dev._live TO DBT_CLOUD_arbitrum;
--  GRANT USAGE ON ALL FUNCTIONS IN SCHEMA arbitrum_dev._live TO DBT_CLOUD_arbitrum;
-- SHOW GRANTS ON FUNCTION arbitrum_dev._UTILS.UDF_INTROSPECT(VARCHAR);
--  GRANT USAGE ON SCHEMA arbitrum_dev._utils TO AWS_LAMBDA_arbitrum_API;
--  GRANT USAGE ON ALL FUNCTIONS IN SCHEMA arbitrum_dev._utils TO AWS_LAMBDA_arbitrum_API;
--  GRANT USAGE ON SCHEMA arbitrum_dev._utils TO DBT_CLOUD_arbitrum;
--  GRANT USAGE ON ALL FUNCTIONS IN SCHEMA arbitrum_dev._utils TO DBT_CLOUD_arbitrum;

kick off curated job