### PR TITLE
arbitrum/v4.19.3

### DIFF
--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,3 @@
 packages:
   - git: https://github.com/FlipsideCrypto/fsc-evm.git
-    revision: v4.18.0
+    revision: v4.19.3


### PR DESCRIPTION
## Summary
Update fsc-evm package to v4.19.3 to include symbiosis-v1 recency exclusion fix.

## Changes
- Update packages.yml revision from v4.18.0 to v4.19.3

## Deployment Plan
After fsc-evm v4.19.3 is tagged and released:
- Merge this PR
- Run `dbt deps` to update dependencies

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>