### PR TITLE
arbitrum/v4.27.6

### DIFF
--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,3 @@
 packages:
   - git: https://github.com/FlipsideCrypto/fsc-evm.git
-    revision: v4.26.0
+    revision: v4.27.6


### PR DESCRIPTION
## Summary
- Update fsc-evm package from v4.26.0 to v4.27.6
- Includes exclusion of fraxswap-v1 from curated recency test

## Root Cause
fraxswap-v1 was failing the daily curated recency test due to low activity (9.81% below 10% threshold)

## Deployment plan
- Merge fsc-evm PR first to create v4.27.6 tag
- Merge this PR after fsc-evm version is available
- Monitor daily tests to confirm resolution

## Test plan
- Verify daily curated recency test passes
- Confirm fraxswap-v1 is properly excluded from recency checks